### PR TITLE
fix: ensuring we are grabbing the most recent run for a model id

### DIFF
--- a/src/webapp/routers/front_end_tables.py
+++ b/src/webapp/routers/front_end_tables.py
@@ -449,6 +449,7 @@ def get_model_cards(
             ModelTable.name == model_name,
             ModelTable.inst_id == str_to_uuid(inst_id),
         )
+        .order_by(JobTable.triggered_at.desc())
     ).first()
 
     if job_result is None or not job_result.model_run_id:


### PR DESCRIPTION
We get multiple model_run_ids for the same model name/id, so this fix ensures the endpoint always selects the most recent run_id for that model.

This raises a follow-up question, do we ever want to fetch an older model card? Since every retraining generates a new one, we should decide how to support historical cards. As implemented now, the endpoint returns the most recent model card (the latest model version).