### PR TITLE
feat: Add case-insensitive institution name lookup

### DIFF
--- a/src/webapp/routers/institutions.py
+++ b/src/webapp/routers/institutions.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException, status, APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
-from sqlalchemy import and_, delete
+from sqlalchemy import and_, delete, func
 
 from ..utilities import (
     has_access_to_inst_or_err,
@@ -152,7 +152,7 @@ def create_institution(
             requested_schemas += PDP_SCHEMA_GROUP
         # if no schema is set and PDP is not set, we default to custom.
         if not requested_schemas:
-            requested_schemas = {SchemaType.UNKNOWN}
+            requested_schemas = [SchemaType.UNKNOWN]
         local_session.get().add(
             InstTable(
                 name=req.name,
@@ -357,11 +357,17 @@ def read_inst_name(
     """Returns overview data on a specific institution.
 
     The root-level API view. Only visible to users of that institution or Datakinder access types.
+
+    Note: Name matching is case-insensitive. The function will match institution names
+    regardless of the case of the input parameter. If multiple institutions with the same
+    name (case-insensitive) exist, this will raise an error.
     """
     local_session.set(sql_session)
     query_result = (
         local_session.get()
-        .execute(select(InstTable).where(InstTable.name == inst_name))
+        .execute(
+            select(InstTable).where(func.lower(InstTable.name) == func.lower(inst_name))
+        )
         .all()
     )
 

--- a/src/webapp/routers/institutions_test.py
+++ b/src/webapp/routers/institutions_test.py
@@ -193,6 +193,43 @@ def test_read_inst_by_name(client: TestClient):
     assert response.json() == INSTITUTION_OBJ
 
 
+def test_read_inst_by_name_case_insensitive(client: TestClient):
+    """Test GET /institutions/name/<name> with case-insensitive matching."""
+    # Test with different case variations - should all match
+    test_cases = [
+        "valid_school",  # Original case
+        "Valid_School",  # Title case
+        "VALID_SCHOOL",  # All uppercase
+        "vAlId_ScHoOl",  # Mixed case
+    ]
+
+    for name_variant in test_cases:
+        response = client.get(f"/institutions/name/{name_variant}")
+        assert response.status_code == 200, f"Failed for variant: {name_variant}"
+        assert response.json() == INSTITUTION_OBJ, (
+            f"Response mismatch for variant: {name_variant}"
+        )
+
+
+def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestClient):
+    """Test GET /institutions/name/<name> with lowercase input when DB has mixed case."""
+    # Test that lowercase input matches mixed case in database
+    # Using datakinder_client since regular client doesn't have access to school_1
+    response = datakinder_client.get("/institutions/name/school_1")
+    assert response.status_code == 200
+    # Verify it matches the institution with name "school_1" (lowercase in DB)
+    assert response.json()["name"] == "school_1"
+
+
+def test_read_inst_by_name_case_insensitive_uppercase(datakinder_client: TestClient):
+    """Test GET /institutions/name/<name> with uppercase input."""
+    # Test that uppercase input matches lowercase in database
+    # Using datakinder_client since regular client doesn't have access to school_1
+    response = datakinder_client.get("/institutions/name/SCHOOL_1")
+    assert response.status_code == 200
+    assert response.json()["name"] == "school_1"
+
+
 def test_read_inst_by_pdp_id(client: TestClient):
     """Test GET /institutions/pdp-id/<pdp_id>. For various user access types."""
     # Unauthorized.

--- a/src/webapp/routers/institutions_test.py
+++ b/src/webapp/routers/institutions_test.py
@@ -82,7 +82,9 @@ def session_fixture():
 
 
 @pytest.fixture(name="client")
-def client_fixture(session: sqlalchemy.orm.Session) -> Generator[TestClient, None, None]:
+def client_fixture(
+    session: sqlalchemy.orm.Session,
+) -> Generator[TestClient, None, None]:
     """Unit test mocks setup for a non-DATAKINDER type."""
 
     def get_session_override():
@@ -109,7 +111,9 @@ def client_fixture(session: sqlalchemy.orm.Session) -> Generator[TestClient, Non
 
 
 @pytest.fixture(name="datakinder_client")
-def datakinder_client_fixture(session: sqlalchemy.orm.Session) -> Generator[TestClient, None, None]:
+def datakinder_client_fixture(
+    session: sqlalchemy.orm.Session,
+) -> Generator[TestClient, None, None]:
     """Unit test mocks setup for a DATAKINDER type."""
 
     def get_session_override():
@@ -212,7 +216,9 @@ def test_read_inst_by_name_case_insensitive(client: TestClient) -> None:
         )
 
 
-def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestClient) -> None:
+def test_read_inst_by_name_case_insensitive_lowercase(
+    datakinder_client: TestClient,
+) -> None:
     """Test GET /institutions/name/<name> with lowercase input when DB has mixed case."""
     # Test that lowercase input matches mixed case in database
     # Using datakinder_client since regular client doesn't have access to school_1
@@ -222,7 +228,9 @@ def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestCli
     assert response.json()["name"] == "school_1"
 
 
-def test_read_inst_by_name_case_insensitive_uppercase(datakinder_client: TestClient) -> None:
+def test_read_inst_by_name_case_insensitive_uppercase(
+    datakinder_client: TestClient,
+) -> None:
     """Test GET /institutions/name/<name> with uppercase input."""
     # Test that uppercase input matches lowercase in database
     # Using datakinder_client since regular client doesn't have access to school_1

--- a/src/webapp/routers/institutions_test.py
+++ b/src/webapp/routers/institutions_test.py
@@ -3,6 +3,7 @@
 import uuid
 import os
 from datetime import datetime
+from typing import Generator
 from unittest import mock
 import pytest
 import sqlalchemy
@@ -81,7 +82,7 @@ def session_fixture():
 
 
 @pytest.fixture(name="client")
-def client_fixture(session: sqlalchemy.orm.Session):
+def client_fixture(session: sqlalchemy.orm.Session) -> Generator[TestClient, None, None]:
     """Unit test mocks setup for a non-DATAKINDER type."""
 
     def get_session_override():
@@ -108,7 +109,7 @@ def client_fixture(session: sqlalchemy.orm.Session):
 
 
 @pytest.fixture(name="datakinder_client")
-def datakinder_client_fixture(session: sqlalchemy.orm.Session):
+def datakinder_client_fixture(session: sqlalchemy.orm.Session) -> Generator[TestClient, None, None]:
     """Unit test mocks setup for a DATAKINDER type."""
 
     def get_session_override():
@@ -134,7 +135,7 @@ def datakinder_client_fixture(session: sqlalchemy.orm.Session):
     app.dependency_overrides.clear()
 
 
-def test_read_all_inst(client: TestClient):
+def test_read_all_inst(client: TestClient) -> None:
     """Test GET /institutions."""
 
     # Unauthorized.
@@ -146,7 +147,7 @@ def test_read_all_inst(client: TestClient):
     )
 
 
-def test_read_all_inst_datakinder(datakinder_client: TestClient):
+def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
     """Test GET /institutions using DATAKINDER type."""
     # Authorized.
     response = datakinder_client.get("/institutions")
@@ -176,7 +177,7 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient):
     ]
 
 
-def test_read_inst_by_name(client: TestClient):
+def test_read_inst_by_name(client: TestClient) -> None:
     """Test GET /institutions/name/<name>. For various user access types."""
     # Unauthorized.
     response = client.get("/institutions/name/school_1")
@@ -193,7 +194,7 @@ def test_read_inst_by_name(client: TestClient):
     assert response.json() == INSTITUTION_OBJ
 
 
-def test_read_inst_by_name_case_insensitive(client: TestClient):
+def test_read_inst_by_name_case_insensitive(client: TestClient) -> None:
     """Test GET /institutions/name/<name> with case-insensitive matching."""
     # Test with different case variations - should all match
     test_cases = [
@@ -211,7 +212,7 @@ def test_read_inst_by_name_case_insensitive(client: TestClient):
         )
 
 
-def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestClient):
+def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestClient) -> None:
     """Test GET /institutions/name/<name> with lowercase input when DB has mixed case."""
     # Test that lowercase input matches mixed case in database
     # Using datakinder_client since regular client doesn't have access to school_1
@@ -221,7 +222,7 @@ def test_read_inst_by_name_case_insensitive_lowercase(datakinder_client: TestCli
     assert response.json()["name"] == "school_1"
 
 
-def test_read_inst_by_name_case_insensitive_uppercase(datakinder_client: TestClient):
+def test_read_inst_by_name_case_insensitive_uppercase(datakinder_client: TestClient) -> None:
     """Test GET /institutions/name/<name> with uppercase input."""
     # Test that uppercase input matches lowercase in database
     # Using datakinder_client since regular client doesn't have access to school_1
@@ -230,7 +231,7 @@ def test_read_inst_by_name_case_insensitive_uppercase(datakinder_client: TestCli
     assert response.json()["name"] == "school_1"
 
 
-def test_read_inst_by_pdp_id(client: TestClient):
+def test_read_inst_by_pdp_id(client: TestClient) -> None:
     """Test GET /institutions/pdp-id/<pdp_id>. For various user access types."""
     # Unauthorized.
     response = client.get("/institutions/pdp-id/456")
@@ -247,7 +248,7 @@ def test_read_inst_by_pdp_id(client: TestClient):
     assert response.json() == INSTITUTION_OBJ
 
 
-def test_read_inst(client: TestClient):
+def test_read_inst(client: TestClient) -> None:
     """Test GET /institutions/<uuid>. For various user access types."""
     # Unauthorized.
     response = client.get("/institutions/" + uuid_to_str(UUID_1))


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

### Case-Insensitive Institution Name Matching
- Updated `GET /institutions/name/{inst_name}` endpoint to use case-insensitive matching
- Changed query from `InstTable.name == inst_name` to `func.lower(InstTable.name) == func.lower(inst_name)`
- Added `func` to SQLAlchemy imports
- Updated docstring to document case-insensitive behavior

### Test Coverage
- Added 3 test functions for case-insensitive matching (multiple case variations, lowercase/uppercase inputs)
- All 12 institution tests pass (9 existing + 3 new)

### Code Quality
- Fixed mypy type error: changed `requested_schemas = {SchemaType.UNKNOWN}` to `[SchemaType.UNKNOWN]` for type consistency
- Applied ruff formatting

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

**Problem**: 
The `edvise` repository normalizes institution names to lowercase before querying the API, but the endpoint was case-sensitive, causing lookup failures when database names have different casing.

**Solution**:
Made the endpoint case-insensitive using SQL `LOWER()` on both sides of the comparison, enabling seamless integration with `edvise`'s lowercase normalization and improving user experience.

**Technical Details**:
- Uses SQLAlchemy's `func.lower()` (compatible with MySQL/Cloud SQL)
- Verified no same-name, different-state institutions exist in production (prevents ambiguity)
- All existing tests pass; new tests verify case-insensitive matching