### PR TITLE
Fix institutions_test assert for Black and Ruff format compatibility

### DIFF
--- a/src/webapp/routers/institutions_test.py
+++ b/src/webapp/routers/institutions_test.py
@@ -249,9 +249,8 @@ def test_read_inst_by_name_case_insensitive(client: TestClient) -> None:
     for name_variant in test_cases:
         response = client.get(f"/institutions/name/{name_variant}")
         assert response.status_code == 200, f"Failed for variant: {name_variant}"
-        assert response.json() == INSTITUTION_OBJ, (
-            f"Response mismatch for variant: {name_variant}"
-        )
+        data = response.json()
+        assert data == INSTITUTION_OBJ, f"Response mismatch for variant: {name_variant}"
 
 
 def test_read_inst_by_name_case_insensitive_lowercase(


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
Rewrites the long assert in test_read_inst_by_name_case_insensitive so it fits on one line (≤88 chars). This keeps both Black and Ruff format checks happy and avoids their conflicting multi-line styles. No behavior change.
