### PR TITLE
Cloudbuild updates

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -12,11 +12,6 @@ ENV UV_LINK_MODE=copy
 # Install gcloud cli
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-cli=500.0.0-0 -y
 
-# Install git and ca-certificates
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends git ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
 # Install gh cli
 RUN (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -12,6 +12,11 @@ ENV UV_LINK_MODE=copy
 # Install gcloud cli
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-cli=500.0.0-0 -y
 
+# Install git and ca-certificates
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install gh cli
 RUN (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ allow-direct-references = true
 default-groups = ["dev"]
 
 [tool.uv.sources]
-edvise = { git = "https://github.com/datakind/edvise.git", rev = "main" }
+edvise = { git = "https://github.com/datakind/edvise.git", rev = "develop" }
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,7 @@ allow-direct-references = true
 default-groups = ["dev"]
 
 [tool.uv.sources]
-# Install edvise from GitHub (branch, tag, or commit).
-# Use rev = "main" for default branch, or rev = "v1.0.0" for a release tag.
-edvise = { git = "https://github.com/datakind/edvise.git", rev = "feat/eda_summary_class" }
+edvise = { git = "https://github.com/datakind/edvise.git", rev = "main" }
 
 [tool.ruff]
 line-length = 88

--- a/src/webapp/Dockerfile
+++ b/src/webapp/Dockerfile
@@ -13,6 +13,11 @@ WORKDIR /app
 # Add project files
 ADD uv.lock pyproject.toml /app/
 
+# Install git and ca-certificates
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 RUN uv sync --frozen --no-install-project
 

--- a/src/worker/Dockerfile
+++ b/src/worker/Dockerfile
@@ -13,6 +13,11 @@ WORKDIR /app
 # Add project files
 ADD uv.lock pyproject.toml /app/
 
+# Install git and ca-certificates
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 RUN uv sync --frozen --no-install-project
 

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 [[package]]
 name = "edvise"
 version = "0.1.10"
-source = { git = "https://github.com/datakind/edvise.git?rev=feat%2Feda_summary_class#86ca8dfdacaa0836c3d83b452bac913acbe2dea7" }
+source = { git = "https://github.com/datakind/edvise.git?rev=develop#743e653942415bbf2f90045deba8bc777e85cf9c" }
 dependencies = [
     { name = "databricks-connect", version = "16.1.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "databricks-connect", version = "16.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -4189,7 +4189,7 @@ requires-dist = [
     { name = "cloud-sql-python-connector", extras = ["pymysql"], specifier = "~=1.14.0" },
     { name = "databricks-sdk", specifier = "~=0.38.0" },
     { name = "databricks-sql-connector", specifier = "~=3.5.0" },
-    { name = "edvise", git = "https://github.com/datakind/edvise.git?rev=feat%2Feda_summary_class" },
+    { name = "edvise", git = "https://github.com/datakind/edvise.git?rev=develop" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.4" },
     { name = "google-cloud-storage", specifier = "==2.19.0" },
     { name = "jsonpickle", specifier = "~=4.0.1" },


### PR DESCRIPTION
## changes
- use develop branch for edvise
- Install git in Dockerfiles

## context
Now that we are using edvise via github we need to install the git app in our container. Once develop is merged into main, we can point our edvise source to main.
