### PR TITLE
fix: consolidate databricksify_inst_name in edvise package

### DIFF
--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -16,7 +16,7 @@ from google.api_core import exceptions as gcs_errors
 from .validation_extension import generate_extension_schema
 from .config import databricks_vars, gcs_vars
 from .utilities import SchemaType
-from edvise.utils.api_requests import databricksify_inst_name
+from edvise.utils.databricks import databricksify_inst_name
 from typing import List, Any, Dict, Optional
 from fastapi import HTTPException
 import requests

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -15,7 +15,8 @@ from google.cloud import storage
 from google.api_core import exceptions as gcs_errors
 from .validation_extension import generate_extension_schema
 from .config import databricks_vars, gcs_vars
-from .utilities import databricksify_inst_name, SchemaType
+from .utilities import SchemaType
+from edvise.utils.api_requests import databricksify_inst_name
 from typing import List, Any, Dict, Optional
 from fastapi import HTTPException
 import requests

--- a/src/webapp/routers/front_end_tables.py
+++ b/src/webapp/routers/front_end_tables.py
@@ -16,8 +16,8 @@ from ..utilities import (
     BaseUser,
     str_to_uuid,
     get_current_active_user,
-    databricksify_inst_name,
 )
+from edvise.utils.api_requests import databricksify_inst_name
 
 from ..database import (
     get_session,

--- a/src/webapp/routers/front_end_tables.py
+++ b/src/webapp/routers/front_end_tables.py
@@ -17,7 +17,7 @@ from ..utilities import (
     str_to_uuid,
     get_current_active_user,
 )
-from edvise.utils.api_requests import databricksify_inst_name
+from edvise.utils.databricks import databricksify_inst_name
 
 from ..database import (
     get_session,

--- a/src/webapp/utilities.py
+++ b/src/webapp/utilities.py
@@ -422,34 +422,3 @@ def get_external_bucket_name_from_uuid(inst_id: uuid.UUID) -> Any:
 def get_external_bucket_name(inst_id: str) -> Any:
     """Get the GCP bucket name which has the env prepended taking in the uuid as str."""
     return prepend_env_prefix(inst_id)
-
-
-def databricksify_inst_name(inst_name: str) -> str:
-    """
-    Follow DK standardized rules for naming conventions used in Databricks.
-    """
-    name = inst_name.lower()
-    # This needs to be in order from most verbose and encompassing other replacement keys to least.
-    dk_replacements = {
-        "community technical college": "ctc",
-        "community college": "cc",
-        "of science and technology": "st",
-        "university": "uni",
-        "college": "col",
-    }
-
-    for old, new in dk_replacements.items():
-        name = name.replace(old, new)
-    special_char_replacements = {" & ": " ", "&": " ", "-": " "}
-
-    for old, new in special_char_replacements.items():
-        name = name.replace(old, new)
-
-    # Databricks uses underscores, so we'll do that here.
-    final_name = name.replace(" ", "_")
-
-    # Check to see that no special characters exist
-    pattern = "^[a-z0-9_]*$"
-    if not re.match(pattern, final_name):
-        raise ValueError("Unexpected character found in Databricks compatible name.")
-    return final_name

--- a/src/webapp/utilities_test.py
+++ b/src/webapp/utilities_test.py
@@ -8,7 +8,6 @@ from .utilities import (
     has_full_data_access_or_err,
     uuid_to_str,
 )
-from edvise.utils.api_requests import databricksify_inst_name
 
 from .test_helper import USR, DATAKINDER, VIEWER, UUID_INVALID, USER_VALID_INST_UUID
 
@@ -41,34 +40,3 @@ def test_has_full_data_access_or_err():
         has_full_data_access_or_err(VIEWER, "models")
     assert err.value.status_code == 401
     assert err.value.detail == "Not authorized to view models for this institution."
-
-
-def test_databricksify_inst_name():
-    """
-    Testing databricksifying institution name
-    """
-    assert (
-        databricksify_inst_name("Motlow State Community College") == "motlow_state_cc"
-    )
-    assert (
-        databricksify_inst_name("Metro State University Denver")
-        == "metro_state_uni_denver"
-    )
-    assert databricksify_inst_name("Kentucky State University") == "kentucky_state_uni"
-    assert databricksify_inst_name("Central Arizona College") == "central_arizona_col"
-    assert (
-        databricksify_inst_name("Harrisburg University of Science and Technology")
-        == "harrisburg_uni_st"
-    )
-    assert (
-        databricksify_inst_name("Southeast Kentucky community technical college")
-        == "southeast_kentucky_ctc"
-    )
-    assert (
-        databricksify_inst_name("Northwest State Community College")
-        == "northwest_state_cc"
-    )
-
-    with pytest.raises(ValueError) as err:
-        databricksify_inst_name("Northwest (invalid)")
-    assert "Unexpected character found in Databricks compatible name" in str(err.value)

--- a/src/webapp/utilities_test.py
+++ b/src/webapp/utilities_test.py
@@ -7,8 +7,8 @@ from .utilities import (
     has_access_to_inst_or_err,
     has_full_data_access_or_err,
     uuid_to_str,
-    databricksify_inst_name,
 )
+from edvise.utils.api_requests import databricksify_inst_name
 
 from .test_helper import USR, DATAKINDER, VIEWER, UUID_INVALID, USER_VALID_INST_UUID
 
@@ -71,4 +71,4 @@ def test_databricksify_inst_name():
 
     with pytest.raises(ValueError) as err:
         databricksify_inst_name("Northwest (invalid)")
-    assert str(err.value) == "Unexpected character found in Databricks compatible name."
+    assert "Unexpected character found in Databricks compatible name" in str(err.value)


### PR DESCRIPTION
This does depend on merging this PR in edvise: https://github.com/datakind/edvise/pull/113. Will wait to merge.

Basically we're trying to keep everything DRY between repos.

Summary:
- Remove duplicate databricksify_inst_name function from utilities.py
- Update imports in databricks.py, front_end_tables.py, and utilities_test.py to use edvise.utils.api_requests.databricksify_inst_name
- Update test assertion to match improved error message format from edvise
- Single source of truth now in edvise package with better documentation