### PR TITLE
feat: legacy school type with any-format uploads, PII check, and Edvise Schema (ES) naming (re-added)

### DIFF
--- a/src/webapp/database.py
+++ b/src/webapp/database.py
@@ -218,6 +218,10 @@ class InstTable(Base):
     edvise_id: Mapped[str | None] = mapped_column(
         String(VAR_CHAR_LENGTH), nullable=True
     )
+    # Only populated for Legacy schools (any-format uploads).
+    legacy_id: Mapped[str | None] = mapped_column(
+        String(VAR_CHAR_LENGTH), nullable=True
+    )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/src/webapp/fixtures/validation_error_snapshots/mixed_types_multiple_columns.txt
+++ b/src/webapp/fixtures/validation_error_snapshots/mixed_types_multiple_columns.txt
@@ -8,4 +8,4 @@ Column 'Score' has validation errors:
   • Row 3: Validation failed for greater_than(0) check. Current value: found '-5'
 
 Column 'Student ID' has validation errors:
-  • Row 1: Value must be at least 3 characters long. Current value: found '****' (value masked for privacy)
+  • Row 1: Value must be at least 3 characters long. Current value: found 'AB'

--- a/src/webapp/gcsutil.py
+++ b/src/webapp/gcsutil.py
@@ -341,8 +341,8 @@ class StorageControl(BaseModel):
             allowed_schemas: List of schema/model names allowed.
             base_schema: Base schema dict.
             inst_schema: Optional extension schema with institutions.* blocks.
-            institution_id: Key into inst_schema["institutions"]: "edvise", "pdp", or
-                institution UUID for custom. Default "pdp" for backward compatibility.
+            institution_id: Key into inst_schema["institutions"]: "edvise", "pdp",
+                "legacy" (any-format uploads), or institution UUID for custom. Default "pdp".
             institution_identifier: Optional institution ID (e.g. UUID). Reserved for
                 future use; Edvise uses JSON-based validation only (different shape).
 

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime, date
-from typing import Annotated, Any, Dict, List, Optional, Tuple, Union
+from typing import Annotated, Any, Dict, List, Optional, Tuple, Union, cast
 from pydantic import BaseModel, Field
 from fastapi import APIRouter, Depends, HTTPException, status, Response
 from sqlalchemy import and_, or_
@@ -19,6 +19,7 @@ from cachetools import TTLCache
 
 from ..utilities import (
     has_access_to_inst_or_err,
+    has_at_most_one_school_type,
     has_full_data_access_or_err,
     BaseUser,
     model_owner_and_higher_or_err,
@@ -1254,32 +1255,23 @@ class _ValidationState:
 
 STATE = _ValidationState()
 
+BASE_TTL = 300  # seconds; base schema cache TTL
+EXT_TTL = 120  # seconds; extension schema cache TTL
 
-def validation_helper(
-    source_str: str,
-    inst_id: str,
-    file_name: str,
-    current_user: BaseUser,
-    storage_control: StorageControl,
-    sql_session: Session,
-) -> Any:
-    """Helper function for file validation (self-contained & optimized)."""
-    import time
 
-    # --- access check & quick input validation
-    has_access_to_inst_or_err(inst_id, current_user)
-    if "/" in file_name:
-        raise HTTPException(status_code=422, detail="File name can't contain '/'.")
+def _infer_allowed_schemas_from_filename(file_name: str, inst: Any) -> List[str]:
+    """Infer allowed schema names from file name; legacy may use any name (UNKNOWN).
 
-    # --- bind session once
-    local_session.set(sql_session)
-    sess = local_session.get()
+    Args:
+        file_name: Name of the file (used for keyword inference).
+        inst: Institution row (must have legacy_id attr for legacy fallback).
 
-    AR_RE = STATE._ar_re
-    BASE_TTL = 300  # seconds
-    EXT_TTL = 120  # seconds
+    Returns:
+        Sorted list of allowed schema names (e.g. ["COURSE"], ["STUDENT"], ["UNKNOWN"]).
 
-    # --- filename → allowed_schemas (fast, single pass)
+    Raises:
+        HTTPException: 422 if name is non-descriptive and institution is not legacy.
+    """
     name = os.path.basename(file_name).lower()
     has_course = "course" in name
     has_semester = "semester" in name
@@ -1288,10 +1280,9 @@ def validation_helper(
         or ("cohort" in name)
         or (
             (not has_course)
-            and (AR_RE.search(name) is not None or "deidentified" in name)
+            and (STATE._ar_re.search(name) is not None or "deidentified" in name)
         )
     )
-
     inferred_from_name: set[str] = set()
     if has_course:
         inferred_from_name.add("COURSE")
@@ -1299,220 +1290,295 @@ def validation_helper(
         inferred_from_name.add("STUDENT")
     if has_semester:
         inferred_from_name.add("SEMESTER")
-
     if not inferred_from_name:
+        if getattr(inst, "legacy_id", None):
+            return ["UNKNOWN"]
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=(
                 f"Could not infer model(s) from file name: {name}. "
-                "Filenames should be descriptive (e.g., include 'course', 'cohort', 'student', or 'semester')."
+                "Filenames should be descriptive (e.g., include 'course', 'cohort', "
+                "'student', or 'semester')."
             ),
         )
+    return sorted(inferred_from_name)
 
-    allowed_schemas = sorted(inferred_from_name)
 
-    # --- fetch active base schema (cached)
+def _get_validation_base_schema(sess: Session) -> Tuple[Any, Any, float]:
+    """Return (base_schema_id, base_schema, now) using cache.
+
+    Args:
+        sess: DB session for schema registry query.
+
+    Returns:
+        Tuple of (base_schema_id, base_schema dict, current time.monotonic()).
+
+    Raises:
+        RuntimeError: If no active base schema is registered.
+    """
+    import time
+
     now = time.monotonic()
     base_cache = STATE._base_cache
     if now < base_cache["exp"] and base_cache["val"] is not None:
-        base_schema_id, base_schema = base_cache["val"]  # pylint: disable=unpacking-non-sequence # fmt: skip
+        cached = base_cache["val"]
+        base_schema_id, base_schema = cached  # pylint: disable=unpacking-non-sequence
+        return (base_schema_id, base_schema, now)
+    row = sess.execute(
+        select(SchemaRegistryTable.schema_id, SchemaRegistryTable.json_doc)
+        .where(
+            SchemaRegistryTable.doc_type == DocType.base,
+            SchemaRegistryTable.is_active.is_(True),
+        )
+        .limit(1)
+    ).first()
+    if row is None:
+        raise RuntimeError("No active base schema found")
+    base_schema_id, base_schema = row
+    base_cache["exp"] = now + BASE_TTL
+    base_cache["val"] = (base_schema_id, base_schema)
+    return (base_schema_id, base_schema, now)
+
+
+def _ext_models_set(doc: Optional[dict], inst: Any, inst_id: str) -> set[str]:
+    """Extract model keys from extension document (root or institutions.* layout).
+
+    Args:
+        doc: Extension schema JSON doc (or None).
+        inst: Institution row (for id in institutions lookup).
+        inst_id: Institution id string (for institutions lookup).
+
+    Returns:
+        Set of lowercase model names (e.g. {"student", "course"}).
+    """
+    if not doc or not isinstance(doc, dict):
+        return set()
+    if isinstance(doc.get("data_models"), dict):
+        return {str(k).lower() for k in doc["data_models"].keys()}
+    inst_key_candidates = {str(getattr(inst, "id", "")), inst_id}
+    insts = doc.get("institutions", {})
+    if isinstance(insts, dict):
+        for key in inst_key_candidates:
+            block = insts.get(key)
+            if isinstance(block, dict) and isinstance(block.get("data_models"), dict):
+                return {str(k).lower() for k in block["data_models"].keys()}
+    return set()
+
+
+def _resolve_edvise_schema(
+    sess: Session, now: float
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Resolve schema namespace and extension for Edvise Schema (ES) institutions."""
+    schema_namespace = "edvise"
+    edvise_exp, edvise_doc = STATE._edvise_cache
+    if now < edvise_exp and edvise_doc is not None:
+        inst_schema: Optional[Dict[str, Any]] = edvise_doc
     else:
-        row = sess.execute(
-            select(SchemaRegistryTable.schema_id, SchemaRegistryTable.json_doc)
+        inst_schema = sess.execute(
+            select(SchemaRegistryTable.json_doc)
             .where(
-                SchemaRegistryTable.doc_type == DocType.base,
+                SchemaRegistryTable.is_edvise.is_(True),
                 SchemaRegistryTable.is_active.is_(True),
             )
             .limit(1)
-        ).first()
-        if row is None:
-            raise RuntimeError("No active base schema found")
-        base_schema_id, base_schema = row
-        base_cache["exp"] = now + BASE_TTL
-        base_cache["val"] = (base_schema_id, base_schema)
-
-    # --- fetch institution record
-    inst = sess.execute(
-        select(InstTable).where(InstTable.id == str_to_uuid(inst_id))
-    ).scalar_one_or_none()
-    if inst is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Institution {inst_id} not found",
-        )
-
-    bucket = get_external_bucket_name(inst_id)
-    # --- choose / prepare extension schema (try to avoid heavy path)
-    updated_inst_schema: Optional[dict] = None
-
-    def _ext_models_set(doc: Optional[dict]) -> set[str]:
-        """Extract model keys from an extension document (root or institutions.* layout)."""
-        if not doc or not isinstance(doc, dict):
-            return set()
-        # root-level
-        if isinstance(doc.get("data_models"), dict):
-            return {str(k).lower() for k in doc["data_models"].keys()}
-        # nested by institution
-        inst_key_candidates = {str(getattr(inst, "id", "")), inst_id}
-        insts = doc.get("institutions", {})
-        if isinstance(insts, dict):
-            for key in inst_key_candidates:
-                block = insts.get(key)
-                if isinstance(block, dict) and isinstance(
-                    block.get("data_models"), dict
-                ):
-                    return {str(k).lower() for k in block["data_models"].keys()}
-        return set()
-
-    # Defensive check: ensure mutual exclusivity (should not happen if validation works correctly)
-    pdp_id = getattr(inst, "pdp_id", None)
-    edvise_id = getattr(inst, "edvise_id", None)
-    if pdp_id and edvise_id:
+        ).scalar_one_or_none()
+        STATE._edvise_cache = (now + EXT_TTL, inst_schema)
+    if inst_schema is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Institution configuration error: cannot have both pdp_id and edvise_id set",
+            detail="Edvise Schema (ES) not found for institution with edvise_id. "
+            "Please ensure an active Edvise Schema (ES) extension is registered.",
         )
+    return (schema_namespace, inst_schema)
 
-    # schema_namespace is the key into extension_schema["institutions"] during
-    # validation so merge_model_columns uses the correct block (edvise / pdp / inst).
-    if edvise_id:
-        # Edvise institutions: use active Edvise extension (cached)
-        schema_namespace = "edvise"
-        edvise_exp, edvise_doc = STATE._edvise_cache
-        if now < edvise_exp and edvise_doc is not None:
-            inst_schema: Optional[Dict[str, Any]] = edvise_doc
-        else:
-            inst_schema = sess.execute(
-                select(SchemaRegistryTable.json_doc)
-                .where(
-                    SchemaRegistryTable.is_edvise.is_(True),
-                    SchemaRegistryTable.is_active.is_(True),
-                )
-                .limit(1)
-            ).scalar_one_or_none()
-            STATE._edvise_cache = (now + EXT_TTL, inst_schema)
-        if inst_schema is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Edvise schema not found for institution with edvise_id. Please ensure an active Edvise schema extension is registered.",
-            )
-        updated_inst_schema = inst_schema
-    elif pdp_id:
-        # PDP institutions: use active PDP extension (cached)
-        schema_namespace = "pdp"
-        pdp_exp, pdp_doc = STATE._pdp_cache
-        if now < pdp_exp and pdp_doc is not None:
-            inst_schema = pdp_doc
-        else:
-            inst_schema = sess.execute(
+
+def _resolve_pdp_schema(
+    sess: Session, now: float
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Resolve schema namespace and extension for PDP institutions."""
+    schema_namespace = "pdp"
+    pdp_exp, pdp_doc = STATE._pdp_cache
+    if now < pdp_exp and pdp_doc is not None:
+        inst_schema: Optional[Dict[str, Any]] = pdp_doc
+    else:
+        inst_schema = cast(
+            Optional[Dict[str, Any]],
+            sess.execute(
                 select(SchemaRegistryTable.json_doc)
                 .where(
                     SchemaRegistryTable.is_pdp.is_(True),
                     SchemaRegistryTable.is_active.is_(True),
                 )
                 .limit(1)
-            ).scalar_one_or_none()
-            STATE._pdp_cache = (now + EXT_TTL, inst_schema)
-        if inst_schema is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="PDP schema not found for institution with pdp_id. Please ensure an active PDP schema extension is registered.",
+            ).scalar_one_or_none(),
+        )
+        STATE._pdp_cache = (now + EXT_TTL, inst_schema)
+    if inst_schema is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="PDP schema not found for institution with pdp_id. "
+            "Please ensure an active PDP schema extension is registered.",
+        )
+    return (schema_namespace, inst_schema)
+
+
+def _persist_custom_schema_extension(
+    sess: Session,
+    inst_id: str,
+    schema_extension: Dict[str, Any],
+    base_schema_id: Any,
+    cache_key: str,
+) -> None:
+    """Deactivate existing extension records and insert new one; update cache."""
+    import time
+
+    existing_extensions = (
+        sess.execute(
+            select(SchemaRegistryTable).where(
+                SchemaRegistryTable.inst_id == str_to_uuid(inst_id),
+                SchemaRegistryTable.doc_type == DocType.extension,
+                SchemaRegistryTable.is_active.is_(True),
             )
-        updated_inst_schema = inst_schema
+        )
+        .scalars()
+        .all()
+    )
+    for existing in existing_extensions:
+        existing.is_active = False
+    new_record = SchemaRegistryTable(
+        doc_type=DocType.extension,
+        inst_id=str_to_uuid(inst_id),
+        is_pdp=False,  # type: ignore
+        version_label="1.0.0",
+        extends_schema_id=base_schema_id,
+        json_doc=schema_extension,
+        is_active=True,
+    )
+    sess.add(new_record)
+    sess.flush()
+    logging.info(
+        "Schema record inserted for '%s' (deactivated %d existing)",
+        inst_id,
+        len(existing_extensions),
+    )
+    STATE._ext_cache[cache_key] = (time.monotonic() + EXT_TTL, schema_extension)
+
+
+def _resolve_custom_schema(
+    sess: Session,
+    inst: Any,
+    inst_id: str,
+    now: float,
+    allowed_schemas: List[str],
+    bucket: str,
+    base_schema: dict,
+    base_schema_id: Any,
+    file_name: str,
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Resolve schema namespace and extension for custom (non-PDP/ES/legacy) institutions."""
+    schema_namespace = str(getattr(inst, "id", ""))
+    ext_cache = STATE._ext_cache
+    key = str(getattr(inst, "id", ""))
+    cached = ext_cache.get(key)
+    if cached and now < cached[0]:
+        inst_schema = cached[1]
     else:
-        # custom institutions: try cached extension first
-        schema_namespace = str(getattr(inst, "id", ""))
-        ext_cache = STATE._ext_cache
-        key = str(getattr(inst, "id", ""))
-        cached = ext_cache.get(key)
-        if cached and now < cached[0]:
-            inst_schema = cached[1]
-        else:
-            inst_schema = sess.execute(
-                select(SchemaRegistryTable.json_doc)
-                .where(
-                    SchemaRegistryTable.inst_id == getattr(inst, "id", None),
-                    SchemaRegistryTable.is_active.is_(True),
-                    SchemaRegistryTable.doc_type == DocType.extension,
-                )
-                .limit(1)
-            ).scalar_one_or_none()
-            ext_cache[key] = (now + EXT_TTL, inst_schema)
-
-        # If extension already includes all inferred models, skip Databricks work.
-        inferred_lower = {m.lower() for m in allowed_schemas}
-        ext_models = _ext_models_set(inst_schema)
-        if inferred_lower.issubset(ext_models):
-            updated_inst_schema = inst_schema
-        else:
-            # heavy path only when needed
-            dbc = DatabricksControl()
-            schema_extension: Optional[Dict[str, Any]] = (
-                dbc.create_custom_schema_extension(
-                    bucket_name=bucket,
-                    inst_query=inst,
-                    file_name=file_name,
-                    base_schema=base_schema,
-                    extension_schema=inst_schema,
-                )
+        inst_schema = sess.execute(
+            select(SchemaRegistryTable.json_doc)
+            .where(
+                SchemaRegistryTable.inst_id == getattr(inst, "id", None),
+                SchemaRegistryTable.is_active.is_(True),
+                SchemaRegistryTable.doc_type == DocType.extension,
             )
-            if schema_extension is not None:
-                updated_inst_schema = schema_extension
-                try:
-                    # Deactivate existing extension records for this institution
-                    # to ensure only one active extension per institution
-                    existing_extensions = (
-                        sess.execute(
-                            select(SchemaRegistryTable).where(
-                                SchemaRegistryTable.inst_id == str_to_uuid(inst_id),
-                                SchemaRegistryTable.doc_type == DocType.extension,
-                                SchemaRegistryTable.is_active.is_(True),
-                            )
-                        )
-                        .scalars()
-                        .all()
-                    )
-                    for existing in existing_extensions:
-                        existing.is_active = False
+            .limit(1)
+        ).scalar_one_or_none()
+        ext_cache[key] = (now + EXT_TTL, inst_schema)
+    inferred_lower = {m.lower() for m in allowed_schemas}
+    ext_models = _ext_models_set(inst_schema, inst, inst_id)
+    if inferred_lower.issubset(ext_models):
+        return (schema_namespace, inst_schema)
+    dbc = DatabricksControl()
+    schema_extension: Optional[Dict[str, Any]] = dbc.create_custom_schema_extension(
+        bucket_name=bucket,
+        inst_query=inst,
+        file_name=file_name,
+        base_schema=base_schema,
+        extension_schema=inst_schema,
+    )
+    if schema_extension is not None:
+        try:
+            _persist_custom_schema_extension(
+                sess, inst_id, schema_extension, base_schema_id, key
+            )
+        except IntegrityError as e:
+            sess.rollback()
+            logging.warning("IntegrityError: %s", e)
+        except Exception as e:
+            sess.rollback()
+            logging.error("Unexpected DB error: %s", e)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Unexpected database error while inserting file record: {e}",
+            )
+        return (schema_namespace, schema_extension)
+    logging.info("No-op: extension already contains this model for inst %s", inst_id)
+    return (schema_namespace, inst_schema)
 
-                    new_schema_extension_record = SchemaRegistryTable(
-                        doc_type=DocType.extension,
-                        inst_id=str_to_uuid(inst_id),
-                        is_pdp=False,  # type: ignore
-                        version_label="1.0.0",
-                        extends_schema_id=base_schema_id,
-                        json_doc=schema_extension,
-                        is_active=True,
-                    )
-                    sess.add(new_schema_extension_record)
-                    sess.flush()
-                    logging.info(
-                        "Schema record inserted for '%s' (deactivated %d existing)",
-                        inst_id,
-                        len(existing_extensions),
-                    )
-                    # refresh cache
-                    STATE._ext_cache[key] = (
-                        time.monotonic() + EXT_TTL,
-                        schema_extension,
-                    )
-                except IntegrityError as e:
-                    sess.rollback()
-                    logging.warning("IntegrityError: %s", e)
-                except Exception as e:
-                    sess.rollback()
-                    logging.error("Unexpected DB error: %s", e)
-                    raise HTTPException(
-                        status_code=500,
-                        detail=f"Unexpected database error while inserting file record: {e}",
-                    )
-            else:
-                logging.info(
-                    "No-op: extension already contains this model for inst %s", inst_id
-                )
-                updated_inst_schema = inst_schema
 
-    # --- run file validation (I/O + Pandera work happens inside storage layer)
+def _resolve_schema_namespace_and_extension(
+    sess: Session,
+    inst: Any,
+    inst_id: str,
+    now: float,
+    allowed_schemas: List[str],
+    bucket: str,
+    base_schema: dict,
+    base_schema_id: Any,
+    file_name: str,
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Resolve schema_namespace and updated_inst_schema by institution type (edvise/pdp/legacy/custom)."""
+    pdp_id = getattr(inst, "pdp_id", None)
+    edvise_id = getattr(inst, "edvise_id", None)
+    legacy_id = getattr(inst, "legacy_id", None)
+    if not has_at_most_one_school_type(pdp_id, edvise_id, legacy_id):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Institution configuration error: cannot have more than one of "
+            "pdp_id, edvise_id, or legacy_id set",
+        )
+    if edvise_id:
+        return _resolve_edvise_schema(sess, now)
+    if pdp_id:
+        return _resolve_pdp_schema(sess, now)
+    if legacy_id:
+        return ("legacy", None)
+    return _resolve_custom_schema(
+        sess,
+        inst,
+        inst_id,
+        now,
+        allowed_schemas,
+        bucket,
+        base_schema,
+        base_schema_id,
+        file_name,
+    )
+
+
+def _run_validation_and_upsert_file_record(
+    bucket: str,
+    file_name: str,
+    allowed_schemas: List[str],
+    base_schema: dict,
+    updated_inst_schema: Optional[Dict[str, Any]],
+    schema_namespace: str,
+    inst_id: str,
+    source_str: str,
+    current_user: BaseUser,
+    storage_control: StorageControl,
+    sess: Session,
+) -> Dict[str, Any]:
+    """Run storage validate_file, then upsert file record and return response dict."""
     try:
         inferred_schemas = storage_control.validate_file(
             bucket,
@@ -1523,14 +1589,11 @@ def validation_helper(
             institution_id=schema_namespace,
             institution_identifier=inst_id if schema_namespace == "edvise" else None,
         )
-        logging.debug("Inferred Schemas success %s", list(inferred_schemas))
     except HardValidationError as e:
         logging.debug("Inferred Schemas FAILED (hard) %s", e)
-        # Format error message for user-friendly display
         try:
             formatted_msg = format_validation_error(e)
         except Exception as format_err:
-            # Fallback to technical message if formatting fails
             logging.warning("Error formatting validation message: %s", format_err)
             parts = ["VALIDATION_FAILED"]
             if e.missing_required:
@@ -1549,8 +1612,7 @@ def validation_helper(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"VALIDATION_ERROR: {type(e).__name__}: {e}",
         )
-
-    # --- upsert file record (cheap path)
+    logging.debug("Inferred Schemas success %s", list(inferred_schemas))
     existing_file = (
         sess.query(FileTable)
         .filter_by(name=file_name, inst_id=str_to_uuid(inst_id))
@@ -1593,7 +1655,6 @@ def validation_helper(
                 status_code=500,
                 detail=f"Unexpected database error while inserting file record: {e}",
             )
-
     return {
         "name": file_name,
         "inst_id": inst_id,
@@ -1601,6 +1662,92 @@ def validation_helper(
         "source": source_str,
         "status": db_status,
     }
+
+
+def validation_helper(
+    source_str: str,
+    inst_id: str,
+    file_name: str,
+    current_user: BaseUser,
+    storage_control: StorageControl,
+    sql_session: Session,
+) -> Any:
+    """Run file validation for an institution and upsert the file record.
+
+    Validates file name and institution, infers allowed schemas from filename
+    (or UNKNOWN for legacy when inference fails), resolves extension schema,
+    runs storage validation, then upserts the file record.
+
+    Args:
+        source_str: Source label for the upload (e.g. MANUAL_UPLOAD).
+        inst_id: Institution UUID (hex string).
+        file_name: Name of the file (no path separators).
+        current_user: Authenticated user; must have access to inst_id.
+        storage_control: StorageControl instance for GCS and validate_file.
+        sql_session: DB session for institution, schema, and file record.
+
+    Returns:
+        Dict with name, inst_id, file_types, source, status.
+
+    Raises:
+        HTTPException: 401 if no access, 404 if institution not found or invalid id,
+            422 if file name invalid or non-descriptive (non-legacy), 400 on validation failure.
+    """
+    has_access_to_inst_or_err(inst_id, current_user)
+    if not file_name or not file_name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="File name is required and must be non-empty.",
+        )
+    if "/" in file_name:
+        raise HTTPException(status_code=422, detail="File name can't contain '/'.")
+
+    local_session.set(sql_session)
+    sess = local_session.get()
+
+    try:
+        inst = sess.execute(
+            select(InstTable).where(InstTable.id == str_to_uuid(inst_id))
+        ).scalar_one_or_none()
+    except (ValueError, TypeError):
+        logging.warning("Invalid institution id for validation: %s", inst_id)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Institution not found or invalid identifier.",
+        )
+    if inst is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Institution {inst_id} not found",
+        )
+
+    allowed_schemas = _infer_allowed_schemas_from_filename(file_name, inst)
+    base_schema_id, base_schema, now = _get_validation_base_schema(sess)
+    bucket = get_external_bucket_name(inst_id)
+    schema_namespace, updated_inst_schema = _resolve_schema_namespace_and_extension(
+        sess,
+        inst,
+        inst_id,
+        now,
+        allowed_schemas,
+        bucket,
+        base_schema,
+        base_schema_id,
+        file_name,
+    )
+    return _run_validation_and_upsert_file_record(
+        bucket,
+        file_name,
+        allowed_schemas,
+        base_schema,
+        updated_inst_schema,
+        schema_namespace,
+        inst_id,
+        source_str,
+        current_user,
+        storage_control,
+        sess,
+    )
 
 
 @router.post(

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -29,7 +29,14 @@ from ..database import (
     get_session,
 )
 from ..utilities import uuid_to_str, get_current_active_user, SchemaType
-from .data import router, DataOverview, DataInfo
+from .data import (
+    router,
+    DataOverview,
+    DataInfo,
+    _infer_allowed_schemas_from_filename,
+    _ext_models_set,
+)
+from fastapi import HTTPException
 from ..gcsutil import StorageControl
 
 MOCK_STORAGE = mock.Mock()
@@ -888,11 +895,85 @@ def test_get_eda_data_success(
 EDVISE_INST_UUID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 EDVISE_INST_2_UUID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 EDVISE_SCHEMA_UUID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+LEGACY_INST_UUID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+
+@pytest.fixture(name="legacy_session")
+def legacy_session_fixture():
+    """Database setup for Legacy (any-format) tests: one institution with legacy_id."""
+    engine = sqlalchemy.create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    try:
+        with sqlalchemy.orm.Session(engine) as session:
+            session.add_all(
+                [
+                    InstTable(
+                        id=LEGACY_INST_UUID,
+                        name="legacy_school",
+                        legacy_id="legacy123",
+                        pdp_id=None,
+                        edvise_id=None,
+                        schemas=["STUDENT", "COURSE"],
+                        created_at=DATETIME_TESTING,
+                        updated_at=DATETIME_TESTING,
+                    ),
+                    SchemaRegistryTable(
+                        doc_type=DocType.base,
+                        is_pdp=False,
+                        is_edvise=False,
+                        version_label="1.0.0",
+                        json_doc={"version": "1.0.0", "base": {"data_models": {}}},
+                        is_active=True,
+                        created_at=DATETIME_TESTING,
+                    ),
+                ]
+            )
+            session.commit()
+            yield session
+    finally:
+        Base.metadata.drop_all(engine)
+
+
+@pytest.fixture(name="legacy_client")
+def legacy_client_fixture(
+    legacy_session: sqlalchemy.orm.Session, monkeypatch: Any
+) -> Any:
+    """Test client for Legacy institution tests."""
+    monkeypatch.setenv("SST_SKIP_EXT_GEN", "1")
+
+    def get_session_override():
+        return legacy_session
+
+    def get_current_active_user_override():
+        from ..utilities import AccessType, BaseUser
+
+        return BaseUser(
+            uuid_to_str(USER_UUID),
+            None,
+            AccessType.DATAKINDER,
+            "abc@example.com",
+        )
+
+    def storage_control_override():
+        return MOCK_STORAGE
+
+    app.include_router(router)
+    app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_current_active_user] = get_current_active_user_override
+    app.dependency_overrides[StorageControl] = storage_control_override
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
 
 
 @pytest.fixture(name="edvise_session")
 def edvise_session_fixture():
-    """Unit test database setup for Edvise tests."""
+    """Unit test database setup for Edvise Schema (ES) tests."""
     engine = sqlalchemy.create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
@@ -900,7 +981,7 @@ def edvise_session_fixture():
     )
     Base.metadata.create_all(engine)
 
-    # Mock Edvise schema extension
+    # Mock Edvise Schema (ES) extension (schema type, not product)
     edvise_schema_doc = {
         "version": "1.0.0",
         "institutions": {
@@ -979,7 +1060,7 @@ def edvise_session_fixture():
 def edvise_client_fixture(
     edvise_session: sqlalchemy.orm.Session, monkeypatch: Any
 ) -> Any:
-    """Unit test mocks setup for Edvise tests."""
+    """Unit test mocks setup for Edvise Schema (ES) tests."""
     monkeypatch.setenv("SST_SKIP_EXT_GEN", "1")
 
     def get_session_override():
@@ -987,7 +1068,7 @@ def edvise_client_fixture(
 
     def get_current_active_user_override():
         # Create DATAKINDER user with access to all institutions (needed for tests
-        # that access multiple Edvise institutions)
+        # that access multiple Edvise Schema (ES) institutions)
         from ..utilities import AccessType, BaseUser
 
         return BaseUser(
@@ -1015,7 +1096,7 @@ def edvise_client_fixture(
 
 
 def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
-    """Test file upload validation uses Edvise schema when edvise_id is set."""
+    """Test file upload validation uses Edvise Schema (ES) when edvise_id is set."""
     MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
 
     response = edvise_client.post(
@@ -1030,17 +1111,245 @@ def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
     assert response.json()["inst_id"] == uuid_to_str(EDVISE_INST_UUID)
     assert response.json()["source"] == "MANUAL_UPLOAD"
 
-    # Verify that validate_file was called with institution_identifier for Edvise
+    # Verify that validate_file was called with institution_identifier for Edvise Schema (ES)
     assert MOCK_STORAGE.validate_file.called
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_identifier") == uuid_to_str(EDVISE_INST_UUID)
 
 
+def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
+    """Test file upload validation uses legacy (any-format) path when legacy_id is set."""
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+
+    response = legacy_client.post(
+        "/institutions/"
+        + uuid_to_str(LEGACY_INST_UUID)
+        + "/input/validate-upload/legacy_student_data.csv",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "legacy_student_data.csv"
+    assert response.json()["file_types"] == ["STUDENT"]
+    assert response.json()["inst_id"] == uuid_to_str(LEGACY_INST_UUID)
+
+    assert MOCK_STORAGE.validate_file.called
+    call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
+    assert call_kwargs.get("institution_id") == "legacy"
+
+
+def test_validate_upload_rejects_empty_file_name(legacy_client: TestClient) -> None:
+    """Empty or whitespace-only file name returns 422."""
+    # Trailing space in path decodes to " "
+    response = legacy_client.post(
+        "/institutions/" + uuid_to_str(LEGACY_INST_UUID) + "/input/validate-upload/%20",
+    )
+    assert response.status_code == 422
+    assert (
+        "required" in response.json()["detail"].lower()
+        or "non-empty" in response.json()["detail"].lower()
+    )
+
+
+def test_validate_upload_invalid_inst_id_returns_404(legacy_client: TestClient) -> None:
+    """Invalid institution id (non-UUID) returns 404, not 500."""
+    response = legacy_client.post(
+        "/institutions/not-a-valid-uuid/input/validate-upload/foo.csv",
+    )
+    assert response.status_code == 404
+    assert (
+        "institution" in response.json()["detail"].lower()
+        or "invalid" in response.json()["detail"].lower()
+    )
+
+
+def test_validate_file_legacy_accepts_arbitrary_filename(
+    legacy_client: TestClient,
+) -> None:
+    """Legacy schools may use any filename; when inference fails, allowed_schemas is UNKNOWN."""
+    MOCK_STORAGE.validate_file.return_value = ["UNKNOWN"]
+
+    response = legacy_client.post(
+        "/institutions/"
+        + uuid_to_str(LEGACY_INST_UUID)
+        + "/input/validate-upload/export_2024.csv",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "export_2024.csv"
+    assert response.json()["file_types"] == ["UNKNOWN"]
+    assert response.json()["inst_id"] == uuid_to_str(LEGACY_INST_UUID)
+
+    assert MOCK_STORAGE.validate_file.called
+    # allowed_schemas is passed positionally (args[2])
+    assert MOCK_STORAGE.validate_file.call_args.args[2] == ["UNKNOWN"]
+    assert MOCK_STORAGE.validate_file.call_args.kwargs.get("institution_id") == "legacy"
+
+
+def test_validate_file_legacy_pii_rejection_returns_400(
+    legacy_client: TestClient,
+) -> None:
+    """When legacy validation raises HardValidationError (e.g. PII columns), API returns 400."""
+    from ..validation import HardValidationError
+
+    MOCK_STORAGE.validate_file.side_effect = HardValidationError(
+        schema_errors="Legacy upload: file contains columns that may contain personally identifiable information (PII).",
+        failure_cases=["email", "first_name"],
+    )
+
+    response = legacy_client.post(
+        "/institutions/"
+        + uuid_to_str(LEGACY_INST_UUID)
+        + "/input/validate-upload/legacy_student_data.csv",
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "PII" in detail or "personally" in detail.lower()
+
+    MOCK_STORAGE.validate_file.side_effect = None
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+
+
+# --- Unit tests for validation helpers ---
+
+
+def _make_inst(legacy_id: Any = None) -> Any:
+    """Minimal institution-like object for _infer_allowed_schemas_from_filename."""
+
+    class Inst:
+        legacy_id: Any = None
+
+    inst = Inst()
+    inst.legacy_id = legacy_id
+    return inst
+
+
+def test_infer_allowed_schemas_course_only() -> None:
+    """Filename with 'course' infers [COURSE]."""
+    inst = _make_inst(legacy_id=None)
+    assert _infer_allowed_schemas_from_filename("course_export.csv", inst) == ["COURSE"]
+
+
+def test_infer_allowed_schemas_student_only() -> None:
+    """Filename with 'student' infers [STUDENT]."""
+    inst = _make_inst(legacy_id=None)
+    assert _infer_allowed_schemas_from_filename("student_data.csv", inst) == ["STUDENT"]
+
+
+def test_infer_allowed_schemas_semester_only() -> None:
+    """Filename with 'semester' infers [SEMESTER]."""
+    inst = _make_inst(legacy_id=None)
+    assert _infer_allowed_schemas_from_filename("semester.csv", inst) == ["SEMESTER"]
+
+
+def test_infer_allowed_schemas_cohort_infers_student() -> None:
+    """Filename with 'cohort' (no course) infers [STUDENT]."""
+    inst = _make_inst(legacy_id=None)
+    assert _infer_allowed_schemas_from_filename("cohort_2024.csv", inst) == ["STUDENT"]
+
+
+def test_infer_allowed_schemas_multiple_keywords() -> None:
+    """Filename with student and course infers both, sorted."""
+    inst = _make_inst(legacy_id=None)
+    result = _infer_allowed_schemas_from_filename("student_course_combined.csv", inst)
+    assert sorted(result) == ["COURSE", "STUDENT"]
+
+
+def test_infer_allowed_schemas_legacy_arbitrary_returns_unknown() -> None:
+    """Legacy institution with non-descriptive filename gets [UNKNOWN]."""
+    inst = _make_inst(legacy_id="legacy_1")
+    assert _infer_allowed_schemas_from_filename("report_2024.csv", inst) == ["UNKNOWN"]
+
+
+def test_infer_allowed_schemas_non_legacy_arbitrary_raises_422() -> None:
+    """Non-legacy institution with non-descriptive filename raises 422."""
+    inst = _make_inst(legacy_id=None)
+    with pytest.raises(HTTPException) as exc_info:
+        _infer_allowed_schemas_from_filename("random.csv", inst)
+    assert exc_info.value.status_code == 422
+    assert "Could not infer model(s)" in exc_info.value.detail
+    assert "random" in exc_info.value.detail
+
+
+def test_ext_models_set_none_returns_empty() -> None:
+    """None doc returns empty set."""
+    inst = _make_inst()
+    assert _ext_models_set(None, inst, "inst-id") == set()
+
+
+def test_ext_models_set_root_data_models() -> None:
+    """Doc with root data_models returns lowercase keys."""
+    inst = _make_inst()
+    doc: dict[str, Any] = {"data_models": {"STUDENT": {}, "COURSE": {}}}
+    assert _ext_models_set(doc, inst, "x") == {"course", "student"}
+
+
+def test_ext_models_set_institutions_block() -> None:
+    """Doc with institutions[inst_id].data_models returns keys."""
+    inst = _make_inst()
+    inst.id = uuid.UUID("12345678-1234-1234-1234-123456789abc")  # type: ignore
+    doc: dict[str, Any] = {
+        "institutions": {
+            "12345678123412341234123456789abc": {
+                "data_models": {"student": {}, "course": {}},
+            }
+        }
+    }
+    assert _ext_models_set(doc, inst, "12345678123412341234123456789abc") == {
+        "course",
+        "student",
+    }
+
+
+def test_validate_edvise_non_descriptive_filename_returns_422(
+    edvise_client: TestClient,
+) -> None:
+    """Edvise institution with non-descriptive filename (no student/course/semester) returns 422."""
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+
+    response = edvise_client.post(
+        "/institutions/"
+        + uuid_to_str(EDVISE_INST_UUID)
+        + "/input/validate-upload/report_2024.csv",
+    )
+
+    assert response.status_code == 422
+    assert "Could not infer model(s)" in response.json()["detail"]
+    assert "report" in response.json()["detail"]
+
+
+def test_validate_upload_second_call_succeeds_and_idempotent(
+    legacy_client: TestClient,
+) -> None:
+    """Validating the same file twice returns 200 both times; no duplicate insert failure."""
+    MOCK_STORAGE.validate_file.return_value = ["UNKNOWN"]
+
+    response1 = legacy_client.post(
+        "/institutions/"
+        + uuid_to_str(LEGACY_INST_UUID)
+        + "/input/validate-upload/duplicate_test.csv",
+    )
+    assert response1.status_code == 200
+    assert response1.json()["name"] == "duplicate_test.csv"
+    assert response1.json()["file_types"] == ["UNKNOWN"]
+
+    response2 = legacy_client.post(
+        "/institutions/"
+        + uuid_to_str(LEGACY_INST_UUID)
+        + "/input/validate-upload/duplicate_test.csv",
+    )
+    assert response2.status_code == 200
+    # Second call hits existing-file path; response payload is unchanged (ValidationResult omits status)
+    assert response2.json()["name"] == response1.json()["name"]
+    assert response2.json()["file_types"] == response1.json()["file_types"]
+    assert response2.json()["inst_id"] == response1.json()["inst_id"]
+
+
 def test_validation_helper_edvise_schema_not_found(
     edvise_client: TestClient, edvise_session: sqlalchemy.orm.Session
 ) -> None:
-    """Test error when edvise_id is set but no active Edvise schema exists."""
-    # Deactivate the Edvise schema
+    """Test error when edvise_id is set but no active Edvise Schema (ES) exists."""
+    # Deactivate the Edvise Schema (ES)
     edvise_schema = edvise_session.execute(
         select(SchemaRegistryTable).where(
             SchemaRegistryTable.is_edvise.is_(True),
@@ -1065,7 +1374,7 @@ def test_validation_helper_edvise_schema_not_found(
     )
 
     assert response.status_code == 500
-    assert "Edvise schema not found" in response.json()["detail"]
+    assert "Edvise Schema (ES) not found" in response.json()["detail"]
     assert "edvise_id" in response.json()["detail"]
 
 
@@ -1094,7 +1403,10 @@ def test_validation_helper_pdp_and_edvise_mutual_exclusivity(
     )
 
     assert response.status_code == 500
-    assert "cannot have both pdp_id and edvise_id set" in response.json()["detail"]
+    assert (
+        "cannot have more than one of pdp_id, edvise_id, or legacy_id set"
+        in response.json()["detail"]
+    )
 
     # Restore for other tests
     corrupted_inst.pdp_id = None  # type: ignore
@@ -1104,7 +1416,7 @@ def test_validation_helper_pdp_and_edvise_mutual_exclusivity(
 def test_edvise_schema_cache(
     edvise_client: TestClient, edvise_session: sqlalchemy.orm.Session
 ) -> None:
-    """Test that Edvise schema is cached and reused."""
+    """Test that Edvise Schema (ES) is cached and reused."""
     from .data import STATE
 
     # Clear cache
@@ -1138,7 +1450,7 @@ def test_edvise_schema_cache(
     assert cache_doc2 is not None
     assert cache_exp2 == cache_exp  # Same expiration means cache was reused
 
-    # Both institutions should use the same cached Edvise schema
+    # Both institutions should use the same cached Edvise Schema (ES)
     assert STATE._edvise_cache[1] is not None
     assert STATE._edvise_cache[1] is cache_doc
 
@@ -1146,7 +1458,7 @@ def test_edvise_schema_cache(
 def test_validate_file_edvise_schema_validation_errors(
     edvise_client: TestClient,
 ) -> None:
-    """Test that validation errors are returned correctly for Edvise schema."""
+    """Test that validation errors are returned correctly for Edvise Schema (ES)."""
     from ..validation import HardValidationError
 
     # Mock validation to raise an error
@@ -1181,7 +1493,7 @@ def test_validate_file_edvise_schema_validation_errors(
 def test_edvise_schema_takes_precedence_over_custom(
     edvise_client: TestClient, edvise_session: sqlalchemy.orm.Session
 ) -> None:
-    """Test that Edvise schema is used instead of custom when edvise_id is set."""
+    """Test that Edvise Schema (ES) is used instead of custom when edvise_id is set."""
     # Add a custom extension for this institution with unique version_label
     custom_schema = SchemaRegistryTable(
         doc_type=DocType.extension,
@@ -1227,12 +1539,12 @@ def test_edvise_schema_takes_precedence_over_custom(
         + "/input/validate-upload/test_student_file.csv",
     )
 
-    # Should succeed using Edvise schema, not custom
+    # Should succeed using Edvise Schema (ES), not custom
     assert response.status_code == 200
 
-    # Verify Edvise schema was passed to validation (not custom)
+    # Verify Edvise Schema (ES) was passed to validation (not custom)
     assert captured_schema is not None
-    # Edvise schema should have "edvise" or "institutions" structure
+    # Edvise Schema (ES) should have "edvise" or "institutions" structure
     assert isinstance(captured_schema, dict)
     assert (
         "edvise" in str(captured_schema).lower()
@@ -1254,7 +1566,7 @@ def test_edvise_schema_takes_precedence_over_custom(
 
 
 def test_validate_sftp_with_edvise_schema(edvise_client: TestClient) -> None:
-    """Test SFTP file validation uses Edvise schema when edvise_id is set."""
+    """Test SFTP file validation uses Edvise Schema (ES) when edvise_id is set."""
     MOCK_STORAGE.validate_file.return_value = ["COURSE"]
 
     response = edvise_client.post(
@@ -1333,7 +1645,7 @@ def test_validate_edvise_invalid_filename(edvise_client: TestClient) -> None:
 
 
 def test_validate_edvise_course_file(edvise_client: TestClient) -> None:
-    """Test COURSE file validation with Edvise schema."""
+    """Test COURSE file validation with Edvise Schema (ES)."""
     MOCK_STORAGE.validate_file.return_value = ["COURSE"]
 
     response = edvise_client.post(
@@ -1396,7 +1708,7 @@ def test_edvise_cache_none_reloads(edvise_client: TestClient) -> None:
 
 
 def test_edvise_cache_shared_across_institutions(edvise_client: TestClient) -> None:
-    """Test that all Edvise institutions share the same cached schema."""
+    """Test that all Edvise Schema (ES) institutions share the same cached schema."""
     from .data import STATE
 
     STATE._edvise_cache = (0.0, None)

--- a/src/webapp/routers/institutions.py
+++ b/src/webapp/routers/institutions.py
@@ -2,7 +2,7 @@
 
 import re
 
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional, Tuple
 from fastapi import HTTPException, status, APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -11,6 +11,7 @@ from sqlalchemy import and_, delete, func
 
 from ..utilities import (
     has_access_to_inst_or_err,
+    has_at_most_one_school_type,
     BaseUser,
     AccessType,
     get_external_bucket_name_from_uuid,
@@ -20,6 +21,7 @@ from ..utilities import (
     SchemaType,
     PDP_SCHEMA_GROUP,
     EDVISE_SCHEMA_GROUP,
+    LEGACY_SCHEMA_GROUP,
     UsState,
     get_external_bucket_name,
 )
@@ -55,9 +57,12 @@ class InstitutionCreationRequest(BaseModel):
     # Note: is_pdp is kept for backward compatibility but is ignored. PDP status is derived from pdp_id presence.
     is_pdp: bool | None = None
     pdp_id: str | None = None
-    # Note: is_edvise is kept for backward compatibility but is ignored. Edvise status is derived from edvise_id presence.
+    # Note: is_edvise is kept for backward compatibility. When True and edvise_id is omitted, edvise_id is auto-assigned.
     is_edvise: bool | None = None
     edvise_id: str | None = None
+    # Legacy schools: upload data in any format. When True and legacy_id is omitted, legacy_id is auto-assigned.
+    is_legacy: bool | None = None
+    legacy_id: str | None = None
     retention_days: int | None = None
 
 
@@ -72,6 +77,7 @@ class Institution(BaseModel):
     retention_days: int | None = None  # In Days
     pdp_id: str | None = None
     edvise_id: str | None = None
+    legacy_id: str | None = None
 
 
 @router.get("/institutions", response_model=list[Institution])
@@ -100,22 +106,82 @@ def read_all_inst(
                 "retention_days": elem[0].retention_days,
                 "pdp_id": None if elem[0].pdp_id is None else elem[0].pdp_id,
                 "edvise_id": None if elem[0].edvise_id is None else elem[0].edvise_id,
+                "legacy_id": None if elem[0].legacy_id is None else elem[0].legacy_id,
             }
         )
     return res
 
 
-@router.post("/institutions", response_model=Institution)
-def create_institution(
+def _request_has_more_than_one_school_type(
     req: InstitutionCreationRequest,
-    current_user: Annotated[BaseUser, Depends(get_current_active_user)],
-    sql_session: Annotated[Session, Depends(get_session)],
-    storage_control: Annotated[StorageControl, Depends(StorageControl)],
-    databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
-) -> Any:
-    """Create a new institution.
+    pdp_id: Optional[str],
+    edvise_id: Optional[str],
+    legacy_id: Optional[str],
+) -> bool:
+    """Return True if the request indicates more than one of PDP, Edvise Schema (ES), or Legacy."""
+    pdp_set = bool(pdp_id)
+    edvise_set = bool(req.is_edvise) or bool(edvise_id)
+    legacy_set = bool(req.is_legacy) or bool(legacy_id)
+    return (pdp_set + edvise_set + legacy_set) > 1
 
-    Only available to Datakinders.
+
+def _compute_edvise_legacy_ids_for_create(
+    sess: Session,
+    req: InstitutionCreationRequest,
+    edvise_id: Optional[str],
+    legacy_id: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    """Auto-assign edvise_id or legacy_id when type is set but no id provided. Returns (edvise_id, legacy_id)."""
+    if req.is_edvise and not edvise_id:
+        count = (
+            sess.execute(
+                select(func.count())
+                .select_from(InstTable)
+                .where(InstTable.edvise_id.isnot(None))
+            ).scalar()
+            or 0
+        )
+        edvise_id = f"edvise_{count + 1}"
+    if req.is_legacy and not legacy_id:
+        count = (
+            sess.execute(
+                select(func.count())
+                .select_from(InstTable)
+                .where(InstTable.legacy_id.isnot(None))
+            ).scalar()
+            or 0
+        )
+        legacy_id = f"legacy_{count + 1}"
+    return (edvise_id, legacy_id)
+
+
+def _build_requested_schemas_for_create(
+    req: InstitutionCreationRequest,
+    pdp_id: Optional[str],
+    edvise_id: Optional[str],
+    legacy_id: Optional[str],
+) -> list:
+    """Build the requested_schemas list from req and school-type IDs. Defaults to [UNKNOWN] if none set."""
+    requested_schemas = list(req.allowed_schemas) if req.allowed_schemas else []
+    if pdp_id:
+        requested_schemas += PDP_SCHEMA_GROUP
+    if edvise_id:
+        requested_schemas += EDVISE_SCHEMA_GROUP
+    if legacy_id:
+        requested_schemas += LEGACY_SCHEMA_GROUP
+    if not requested_schemas:
+        requested_schemas = [SchemaType.UNKNOWN]
+    return list(set(requested_schemas))
+
+
+def _validate_and_prepare_create_institution(
+    req: InstitutionCreationRequest,
+    current_user: BaseUser,
+    sql_session: Session,
+) -> Tuple[Session, Optional[str], Optional[str], Optional[str]]:
+    """
+    Validate request and compute normalized IDs. Returns (sess, pdp_id, edvise_id, legacy_id).
+    Raises HTTPException on validation failure.
     """
     if not current_user.is_datakinder():
         raise HTTPException(
@@ -127,106 +193,148 @@ def create_institution(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Please set the institution name.",
         )
-    # Normalize empty strings to None for consistency
-    # Strip whitespace and convert empty strings to None
     pdp_id = (req.pdp_id or "").strip() or None
     edvise_id = (req.edvise_id or "").strip() or None
-    # Validate mutual exclusivity: cannot be both PDP and Edvise
-    if pdp_id and edvise_id:
+    legacy_id = (req.legacy_id or "").strip() or None
+
+    if _request_has_more_than_one_school_type(req, pdp_id, edvise_id, legacy_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="An institution cannot be both PDP and Edvise. Please choose one schema type.",
+            detail="An institution cannot be more than one of PDP, Edvise Schema (ES), or Legacy. Please choose one schema type.",
         )
-
-    pattern = "^[A-Za-z0-9&_ -]*$"
-    if not re.match(pattern, req.name):
+    local_session.set(sql_session)
+    sess = local_session.get()
+    edvise_id, legacy_id = _compute_edvise_legacy_ids_for_create(
+        sess, req, edvise_id, legacy_id
+    )
+    if not has_at_most_one_school_type(pdp_id, edvise_id, legacy_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="An institution cannot be more than one of PDP, Edvise Schema (ES), or Legacy. Please choose one schema type.",
+        )
+    if not re.match(r"^[A-Za-z0-9&_ -]*$", req.name):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Only alphanumeric characters, -, _, &, and a space are allowed in institution names.",
         )
+    return (sess, pdp_id, edvise_id, legacy_id)
 
-    local_session.set(sql_session)
-    query_result = (
-        local_session.get()
-        .execute(
-            select(InstTable).where(
-                and_(InstTable.name == req.name, InstTable.state == req.state)
-            )
+
+def _institution_row_to_response(row: Any) -> Dict[str, Any]:
+    """Build the Institution response dict from an InstTable row."""
+    return {
+        "inst_id": uuid_to_str(row.id),
+        "name": row.name,
+        "state": row.state,
+        "pdp_id": row.pdp_id,
+        "edvise_id": row.edvise_id,
+        "legacy_id": row.legacy_id,
+        "retention_days": row.retention_days,
+    }
+
+
+def _create_institution_record_and_infrastructure(
+    sess: Session,
+    req: InstitutionCreationRequest,
+    pdp_id: Optional[str],
+    edvise_id: Optional[str],
+    legacy_id: Optional[str],
+    requested_schemas: list,
+    current_user: BaseUser,
+    storage_control: StorageControl,
+    databricks_control: DatabricksControl,
+) -> Any:
+    """
+    Add institution record, commit, create bucket and Databricks setup. Returns the created InstTable row.
+    Raises HTTPException on failure.
+    """
+    sess.add(
+        InstTable(
+            name=req.name,
+            retention_days=req.retention_days,
+            pdp_id=pdp_id,
+            edvise_id=edvise_id,
+            legacy_id=legacy_id,
+            schemas=requested_schemas,
+            allowed_emails=req.allowed_emails,
+            state=req.state,
+            created_by=str_to_uuid(current_user.user_id),
         )
-        .all()
     )
+    sess.commit()
+    query_result = sess.execute(
+        select(InstTable).where(InstTable.name == req.name)
+    ).all()
+    if not query_result:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database write of the institution creation failed.",
+        )
+    if len(query_result) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database write of the institution created duplicate entries.",
+        )
+    inst_row = query_result[0][0]
+    bucket_name = get_external_bucket_name_from_uuid(inst_row.id)
+    try:
+        storage_control.create_bucket(bucket_name)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Storage bucket creation failed:" + str(e),
+        ) from e
+    try:
+        databricks_control.setup_new_inst(inst_row.name)
+    except Exception as e:
+        # DatabricksControl may raise various exceptions; catch and re-raise with context.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Databricks setup failed:" + str(e),
+        ) from e
+    return inst_row
+
+
+@router.post("/institutions", response_model=Institution)
+def create_institution(
+    req: InstitutionCreationRequest,
+    current_user: Annotated[BaseUser, Depends(get_current_active_user)],
+    sql_session: Annotated[Session, Depends(get_session)],
+    storage_control: Annotated[StorageControl, Depends(StorageControl)],
+    databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
+) -> Any:
+    """Create a new institution. Only available to Datakinders."""
+    sess, pdp_id, edvise_id, legacy_id = _validate_and_prepare_create_institution(
+        req, current_user, sql_session
+    )
+    query_result = sess.execute(
+        select(InstTable).where(
+            and_(InstTable.name == req.name, InstTable.state == req.state)
+        )
+    ).all()
     if len(query_result) == 0:
-        # If the institution does not exist create it and create a storage bucket for it.
-        requested_schemas = []
-        if req.allowed_schemas:
-            requested_schemas = req.allowed_schemas
-        # Derive PDP status from pdp_id presence (ignore is_pdp for backward compat)
-        if pdp_id:
-            requested_schemas += PDP_SCHEMA_GROUP
-        # Derive Edvise status from edvise_id presence (ignore is_edvise for backward compat)
-        if edvise_id:
-            requested_schemas += EDVISE_SCHEMA_GROUP
-        # if no schema is set and neither PDP nor Edvise is set, we default to custom.
-        if not requested_schemas:
-            requested_schemas = [SchemaType.UNKNOWN]
-        local_session.get().add(
-            InstTable(
-                name=req.name,
-                retention_days=req.retention_days,
-                pdp_id=pdp_id,
-                edvise_id=edvise_id,
-                # Sets aren't json serializable, so turn them into lists first
-                schemas=list(set(requested_schemas)),
-                allowed_emails=req.allowed_emails,
-                state=req.state,
-                created_by=str_to_uuid(current_user.user_id),
-            )
+        requested_schemas = _build_requested_schemas_for_create(
+            req, pdp_id, edvise_id, legacy_id
         )
-        local_session.get().commit()
-        query_result = (
-            local_session.get()
-            .execute(select(InstTable).where(InstTable.name == req.name))
-            .all()
+        row = _create_institution_record_and_infrastructure(
+            sess,
+            req,
+            pdp_id,
+            edvise_id,
+            legacy_id,
+            requested_schemas,
+            current_user,
+            storage_control,
+            databricks_control,
         )
-        if not query_result:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Database write of the institution creation failed.",
-            )
-        if len(query_result) > 1:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Database write of the institution created duplicate entries.",
-            )
-        # Create a storage bucket for it. During creation, we have to include the /.
-        bucket_name = get_external_bucket_name_from_uuid(query_result[0][0].id)
-        try:
-            storage_control.create_bucket(bucket_name)
-        except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Storage bucket creation failed:" + str(e),
-            ) from e
-        try:
-            databricks_control.setup_new_inst(query_result[0][0].name)
-        except Exception as e:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Databricks setup failed:" + str(e),
-            ) from e
+    else:
+        row = query_result[0][0]
     if len(query_result) > 1:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Institution duplicates found.",
         )
-    return {
-        "inst_id": uuid_to_str(query_result[0][0].id),
-        "name": query_result[0][0].name,
-        "state": query_result[0][0].state,
-        "pdp_id": query_result[0][0].pdp_id,
-        "edvise_id": query_result[0][0].edvise_id,
-        "retention_days": query_result[0][0].retention_days,
-    }
+    return _institution_row_to_response(row)
 
 
 @router.patch("/institutions/{inst_id}", response_model=Institution)
@@ -274,7 +382,9 @@ def update_inst(
         update_data["pdp_id"] = (update_data["pdp_id"] or "").strip() or None
     if "edvise_id" in update_data:
         update_data["edvise_id"] = (update_data["edvise_id"] or "").strip() or None
-    # Validate mutual exclusivity: cannot be both PDP and Edvise
+    if "legacy_id" in update_data:
+        update_data["legacy_id"] = (update_data["legacy_id"] or "").strip() or None
+    # Validate mutual exclusivity: at most one of PDP, Edvise Schema (ES), or Legacy
     final_pdp_id = (
         update_data.get("pdp_id") if "pdp_id" in update_data else existing_inst.pdp_id
     )
@@ -283,10 +393,15 @@ def update_inst(
         if "edvise_id" in update_data
         else existing_inst.edvise_id
     )
-    if final_pdp_id and final_edvise_id:
+    final_legacy_id = (
+        update_data.get("legacy_id")
+        if "legacy_id" in update_data
+        else existing_inst.legacy_id
+    )
+    if not has_at_most_one_school_type(final_pdp_id, final_edvise_id, final_legacy_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="An institution cannot be both PDP and Edvise. Please choose one schema type.",
+            detail="An institution cannot be more than one of PDP, Edvise Schema (ES), or Legacy. Please choose one schema type.",
         )
 
     if "state" in update_data:
@@ -298,9 +413,11 @@ def update_inst(
     # Note: is_pdp is ignored - PDP status is derived from pdp_id presence
     if "pdp_id" in update_data:
         existing_inst.pdp_id = update_data["pdp_id"]
-    # Note: is_edvise is ignored - Edvise status is derived from edvise_id presence
+    # Note: is_edvise is ignored - Edvise Schema (ES) status is derived from edvise_id presence
     if "edvise_id" in update_data:
         existing_inst.edvise_id = update_data["edvise_id"]
+    if "legacy_id" in update_data:
+        existing_inst.legacy_id = update_data["legacy_id"]
     if "retention_days" in update_data:
         existing_inst.retention_days = update_data["retention_days"]
 
@@ -320,6 +437,7 @@ def update_inst(
         "state": res[0][0].state,
         "pdp_id": res[0][0].pdp_id,
         "edvise_id": res[0][0].edvise_id,
+        "legacy_id": res[0][0].legacy_id,
         "retention_days": res[0][0].retention_days,
     }
 
@@ -420,6 +538,7 @@ def read_inst_name(
         "state": query_result[0][0].state,
         "pdp_id": query_result[0][0].pdp_id,
         "edvise_id": query_result[0][0].edvise_id,
+        "legacy_id": query_result[0][0].legacy_id,
     }
 
 
@@ -455,6 +574,7 @@ def read_inst_pdp_id(
         "state": query_result[0][0].state,
         "pdp_id": query_result[0][0].pdp_id,
         "edvise_id": query_result[0][0].edvise_id,
+        "legacy_id": query_result[0][0].legacy_id,
     }
 
 
@@ -492,4 +612,5 @@ def read_inst_id(
         "state": query_result[0][0].state,
         "pdp_id": query_result[0][0].pdp_id,
         "edvise_id": query_result[0][0].edvise_id,
+        "legacy_id": query_result[0][0].legacy_id,
     }

--- a/src/webapp/routers/institutions_test.py
+++ b/src/webapp/routers/institutions_test.py
@@ -28,7 +28,7 @@ from ..databricks import DatabricksControl
 DATETIME_TESTING = datetime.today()
 UUID_1 = uuid.uuid4()
 UUID_2 = uuid.uuid4()
-UUID_3 = uuid.uuid4()  # For Edvise test institution
+UUID_3 = uuid.uuid4()  # For Edvise Schema (ES) test institution
 USER_UUID = uuid.UUID("5301a352-c03d-4a39-beec-16c5668c4700")
 USER_VALID_INST_UUID = uuid.UUID("1d7c75c3-3eda-4294-9c66-75ea8af97b55")
 INVALID_UUID = uuid.UUID("27316b89-5e04-474a-9ea4-97beaf72c9af")
@@ -169,10 +169,11 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
     response = datakinder_client.get("/institutions")
     assert response.status_code == 200
     data = response.json()
-    # Verify all institutions have edvise_id field
+    # Verify all institutions have edvise_id, pdp_id, and legacy_id fields
     for inst in data:
         assert "edvise_id" in inst
         assert "pdp_id" in inst
+        assert "legacy_id" in inst
     # Verify specific expected values
     assert len(data) == 4  # UUID_1, UUID_2, UUID_3, USER_VALID_INST_UUID
     school_1 = next(i for i in data if i["name"] == "school_1")
@@ -187,6 +188,7 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
             "name": "school_1",
             "pdp_id": "456",
             "edvise_id": None,
+            "legacy_id": None,
             "retention_days": None,
             "state": "GA",
         },
@@ -195,6 +197,7 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
             "name": "school_2",
             "pdp_id": None,
             "edvise_id": None,
+            "legacy_id": None,
             "retention_days": None,
             "state": None,
         },
@@ -203,6 +206,7 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
             "name": "valid_school",
             "pdp_id": "12345",
             "edvise_id": None,
+            "legacy_id": None,
             "retention_days": None,
             "state": "NY",
         },
@@ -211,6 +215,7 @@ def test_read_all_inst_datakinder(datakinder_client: TestClient) -> None:
             "name": "edvise_test_school",
             "pdp_id": None,
             "edvise_id": "edvise456",
+            "legacy_id": None,
             "retention_days": None,
             "state": "CA",
         },
@@ -393,12 +398,12 @@ def test_delete_inst(datakinder_client: TestClient) -> None:
 
 
 # ============================================================================
-# CREATE INSTITUTION TESTS - Edvise Functionality
+# CREATE INSTITUTION TESTS - Edvise Schema (ES) functionality
 # ============================================================================
 
 
 def test_create_inst_with_edvise_success(datakinder_client: TestClient) -> None:
-    """Test POST /institutions with Edvise ID - happy path."""
+    """Test POST /institutions with Edvise Schema (ES) (edvise_id) - happy path."""
     os.environ["ENV"] = "DEV"
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
@@ -442,7 +447,7 @@ def test_create_inst_with_edvise_id_only(datakinder_client: TestClient) -> None:
 
 
 def test_create_inst_mutual_exclusivity_error(datakinder_client: TestClient) -> None:
-    """Test POST /institutions with both PDP and Edvise - should fail."""
+    """Test POST /institutions with both PDP and Edvise Schema (ES) - should fail."""
     os.environ["ENV"] = "DEV"
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
@@ -456,7 +461,7 @@ def test_create_inst_mutual_exclusivity_error(datakinder_client: TestClient) -> 
 
     response = datakinder_client.post("/institutions", json=request_data)
     assert response.status_code == 400
-    assert "cannot be both PDP and Edvise" in response.json()["detail"]
+    assert "Please choose one schema type" in response.json()["detail"]
 
 
 def test_create_inst_empty_string_normalization(datakinder_client: TestClient) -> None:
@@ -520,30 +525,124 @@ def test_create_inst_backward_compatibility_is_pdp_ignored(
     assert data["pdp_id"] is None  # No PDP schema assigned
 
 
-def test_create_inst_backward_compatibility_is_edvise_ignored(
+def test_create_inst_auto_assign_edvise_id(
     datakinder_client: TestClient,
 ) -> None:
-    """Test POST /institutions - is_edvise flag is accepted but ignored."""
+    """Test POST /institutions - is_edvise=True with no edvise_id auto-assigns edvise_id."""
     os.environ["ENV"] = "DEV"
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
     MOCK_DATABRICKS.setup_new_inst.return_value = None
 
-    # Send is_edvise=True but no edvise_id - should work (is_edvise ignored)
     request_data = {
-        "name": "backward_compat_edvise_test",
-        "is_edvise": True,  # Should be ignored
-        "edvise_id": None,  # No actual Edvise ID
+        "name": "auto_edvise_test",
+        "is_edvise": True,
+        "edvise_id": None,
     }
 
     response = datakinder_client.post("/institutions", json=request_data)
     assert response.status_code == 200
     data = response.json()
-    assert data["edvise_id"] is None  # No Edvise schema assigned
+    assert data["edvise_id"] is not None and data["edvise_id"].startswith("edvise_")
+    assert data["pdp_id"] is None
+    assert data["legacy_id"] is None
+
+
+def test_create_inst_auto_assign_legacy_id(
+    datakinder_client: TestClient,
+) -> None:
+    """Test POST /institutions - is_legacy=True with no legacy_id auto-assigns legacy_id."""
+    os.environ["ENV"] = "DEV"
+    MOCK_STORAGE.create_bucket.return_value = None
+    MOCK_STORAGE.create_folders.return_value = None
+    MOCK_DATABRICKS.setup_new_inst.return_value = None
+
+    request_data = {
+        "name": "auto_legacy_test",
+        "is_legacy": True,
+        "legacy_id": None,
+    }
+
+    response = datakinder_client.post("/institutions", json=request_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["legacy_id"] == "legacy_1"
+    assert data["pdp_id"] is None
+    assert data["edvise_id"] is None
+
+
+def test_create_inst_reject_both_edvise_and_legacy(
+    datakinder_client: TestClient,
+) -> None:
+    """Test POST /institutions - is_edvise and is_legacy both True returns 400."""
+    request_data = {
+        "name": "both_types_test",
+        "is_edvise": True,
+        "is_legacy": True,
+    }
+    response = datakinder_client.post("/institutions", json=request_data)
+    assert response.status_code == 400
+    assert "cannot be more than one" in response.json()["detail"]
+
+
+def test_create_inst_with_legacy_id_explicit(datakinder_client: TestClient) -> None:
+    """Test POST /institutions with explicit legacy_id (no auto-assign)."""
+    os.environ["ENV"] = "DEV"
+    MOCK_STORAGE.create_bucket.return_value = None
+    MOCK_STORAGE.create_folders.return_value = None
+    MOCK_DATABRICKS.setup_new_inst.return_value = None
+
+    request_data = {
+        "name": "explicit_legacy_school",
+        "state": "TX",
+        "legacy_id": "custom_legacy_123",
+    }
+    response = datakinder_client.post("/institutions", json=request_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["legacy_id"] == "custom_legacy_123"
+    assert data["pdp_id"] is None
+    assert data["edvise_id"] is None
+
+
+def test_create_inst_storage_bucket_fails(datakinder_client: TestClient) -> None:
+    """Test POST /institutions returns 500 when storage bucket creation raises."""
+    os.environ["ENV"] = "DEV"
+    MOCK_STORAGE.create_bucket.side_effect = ValueError("Bucket already exists")
+    MOCK_STORAGE.create_folders.return_value = None
+    MOCK_DATABRICKS.setup_new_inst.return_value = None
+
+    response = datakinder_client.post(
+        "/institutions",
+        json={"name": "school_bucket_fail", "state": "NY"},
+    )
+    assert response.status_code == 500
+    assert "Storage bucket creation failed" in response.json()["detail"]
+
+    MOCK_STORAGE.create_bucket.side_effect = None
+
+
+def test_create_inst_databricks_setup_fails(datakinder_client: TestClient) -> None:
+    """Test POST /institutions returns 500 when Databricks setup raises."""
+    os.environ["ENV"] = "DEV"
+    MOCK_STORAGE.create_bucket.return_value = None
+    MOCK_STORAGE.create_folders.return_value = None
+    MOCK_DATABRICKS.setup_new_inst.side_effect = Exception(
+        "Databricks connection failed"
+    )
+
+    response = datakinder_client.post(
+        "/institutions",
+        json={"name": "school_dbc_fail", "state": "CA"},
+    )
+    assert response.status_code == 500
+    assert "Databricks setup failed" in response.json()["detail"]
+
+    MOCK_DATABRICKS.setup_new_inst.side_effect = None
 
 
 # ============================================================================
-# UPDATE INSTITUTION TESTS - Edvise Functionality
+# UPDATE INSTITUTION TESTS - Edvise Schema (ES) functionality
 # ============================================================================
 
 
@@ -553,7 +652,7 @@ def test_update_inst_add_edvise_id(datakinder_client: TestClient) -> None:
     MOCK_STORAGE.create_folders.return_value = None
     MOCK_DATABRICKS.setup_new_inst.return_value = None
 
-    # Update custom school (UUID_2) to Edvise
+    # Update custom school (UUID_2) to Edvise Schema (ES)
     response = datakinder_client.patch(
         "/institutions/" + uuid_to_str(UUID_2),
         json={"edvise_id": "new_edvise_id"},
@@ -564,13 +663,30 @@ def test_update_inst_add_edvise_id(datakinder_client: TestClient) -> None:
     assert data["pdp_id"] is None
 
 
-def test_update_inst_switch_pdp_to_edvise(datakinder_client: TestClient) -> None:
-    """Test PATCH /institutions - switch from PDP to Edvise."""
+def test_update_inst_add_legacy_id(datakinder_client: TestClient) -> None:
+    """Test PATCH /institutions - add legacy_id to existing custom institution."""
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
     MOCK_DATABRICKS.setup_new_inst.return_value = None
 
-    # First clear PDP, then add Edvise
+    response = datakinder_client.patch(
+        "/institutions/" + uuid_to_str(UUID_2),
+        json={"legacy_id": "legacy_abc"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["legacy_id"] == "legacy_abc"
+    assert data["pdp_id"] is None
+    assert data["edvise_id"] is None
+
+
+def test_update_inst_switch_pdp_to_edvise(datakinder_client: TestClient) -> None:
+    """Test PATCH /institutions - switch from PDP to Edvise Schema (ES)."""
+    MOCK_STORAGE.create_bucket.return_value = None
+    MOCK_STORAGE.create_folders.return_value = None
+    MOCK_DATABRICKS.setup_new_inst.return_value = None
+
+    # First clear PDP, then add Edvise Schema (ES)
     response = datakinder_client.patch(
         "/institutions/" + uuid_to_str(UUID_1),
         json={"pdp_id": None, "edvise_id": "switched_to_edvise"},
@@ -582,12 +698,12 @@ def test_update_inst_switch_pdp_to_edvise(datakinder_client: TestClient) -> None
 
 
 def test_update_inst_switch_edvise_to_pdp(datakinder_client: TestClient) -> None:
-    """Test PATCH /institutions - switch from Edvise to PDP."""
+    """Test PATCH /institutions - switch from Edvise Schema (ES) to PDP."""
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
     MOCK_DATABRICKS.setup_new_inst.return_value = None
 
-    # Switch UUID_3 (Edvise) to PDP
+    # Switch UUID_3 (Edvise Schema (ES)) to PDP
     response = datakinder_client.patch(
         "/institutions/" + uuid_to_str(UUID_3),
         json={"edvise_id": None, "pdp_id": "switched_to_pdp"},
@@ -599,7 +715,7 @@ def test_update_inst_switch_edvise_to_pdp(datakinder_client: TestClient) -> None
 
 
 def test_update_inst_mutual_exclusivity_error(datakinder_client: TestClient) -> None:
-    """Test PATCH /institutions - cannot set both PDP and Edvise."""
+    """Test PATCH /institutions - cannot set both PDP and Edvise Schema (ES)."""
     MOCK_STORAGE.create_bucket.return_value = None
     MOCK_STORAGE.create_folders.return_value = None
     MOCK_DATABRICKS.setup_new_inst.return_value = None
@@ -610,7 +726,7 @@ def test_update_inst_mutual_exclusivity_error(datakinder_client: TestClient) -> 
         json={"pdp_id": "pdp123", "edvise_id": "edvise456"},
     )
     assert response.status_code == 400
-    assert "cannot be both PDP and Edvise" in response.json()["detail"]
+    assert "Please choose one schema type" in response.json()["detail"]
 
 
 def test_update_inst_clear_edvise_id(datakinder_client: TestClient) -> None:
@@ -679,7 +795,7 @@ def test_read_inst_by_id_includes_edvise_id(client: TestClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert "edvise_id" in data
-    assert data["edvise_id"] is None  # This institution doesn't have Edvise
+    assert data["edvise_id"] is None  # This institution doesn't have Edvise Schema (ES)
 
 
 def test_read_inst_by_name_includes_edvise_id(client: TestClient) -> None:
@@ -761,10 +877,10 @@ def test_update_inst_final_state_validation(datakinder_client: TestClient) -> No
     # Institution already has pdp_id, try to add edvise_id
     response = datakinder_client.patch(
         "/institutions/" + uuid_to_str(UUID_1),  # Has pdp_id="456"
-        json={"edvise_id": "edvise999"},  # Try to add Edvise
+        json={"edvise_id": "edvise999"},  # Try to add Edvise Schema (ES)
     )
     assert response.status_code == 400
-    assert "cannot be both PDP and Edvise" in response.json()["detail"]
+    assert "Please choose one schema type" in response.json()["detail"]
 
 
 # ============================================================================
@@ -773,7 +889,7 @@ def test_update_inst_final_state_validation(datakinder_client: TestClient) -> No
 
 
 def test_create_inst_edvise_unauthorized(client: TestClient) -> None:
-    """Test POST /institutions with Edvise - unauthorized user."""
+    """Test POST /institutions with Edvise Schema (ES) - unauthorized user."""
     os.environ["ENV"] = "DEV"
     request_data = {
         "name": "unauthorized_test",
@@ -786,7 +902,7 @@ def test_create_inst_edvise_unauthorized(client: TestClient) -> None:
 
 
 def test_update_inst_edvise_unauthorized(client: TestClient) -> None:
-    """Test PATCH /institutions with Edvise - unauthorized user."""
+    """Test PATCH /institutions with Edvise Schema (ES) - unauthorized user."""
     # Try to update institution user doesn't have access to
     response = client.patch(
         "/institutions/" + uuid_to_str(UUID_1),
@@ -802,7 +918,7 @@ def test_update_inst_edvise_unauthorized(client: TestClient) -> None:
 
 
 def test_read_inst_edvise_tenant_isolation(client: TestClient) -> None:
-    """Test GET /institutions/{inst_id} - cannot access other institution's Edvise data."""
+    """Test GET /institutions/{inst_id} - cannot access other institution's Edvise Schema (ES) data."""
     # Try to access institution user doesn't belong to
     response = client.get("/institutions/" + uuid_to_str(UUID_2))
     assert response.status_code == 401

--- a/src/webapp/test_helper.py
+++ b/src/webapp/test_helper.py
@@ -78,6 +78,8 @@ EMPTY_INSTITUTION_OBJ = {
     "name": "",
     "state": "",
     "pdp_id": None,
+    "edvise_id": None,
+    "legacy_id": None,
     "retention_days": 0,
 }
 
@@ -87,6 +89,7 @@ INSTITUTION_OBJ = {
     "state": "NY",
     "pdp_id": "12345",
     "edvise_id": None,
+    "legacy_id": None,
     "retention_days": None,
 }
 

--- a/src/webapp/utilities.py
+++ b/src/webapp/utilities.py
@@ -152,6 +152,33 @@ EDVISE_SCHEMA_GROUP: Final = {
     SchemaType.COURSE,
 }
 
+LEGACY_SCHEMA_GROUP: Final = {
+    SchemaType.STUDENT,
+    SchemaType.COURSE,
+}
+
+
+def has_at_most_one_school_type(
+    pdp_id: str | None,
+    edvise_id: str | None,
+    legacy_id: str | None,
+) -> bool:
+    """
+    Return True if at most one of pdp_id, edvise_id, or legacy_id is set.
+
+    Used to enforce mutual exclusivity: an institution must be exactly one
+    of PDP, Edvise Schema (ES), or Legacy (or none, for custom).
+
+    Args:
+        pdp_id: PDP institution identifier, or None.
+        edvise_id: Edvise Schema (ES) institution identifier, or None.
+        legacy_id: Legacy institution identifier, or None.
+
+    Returns:
+        True if zero or one of the three IDs is set; False if two or more are set.
+    """
+    return sum(bool(x) for x in (pdp_id, edvise_id, legacy_id)) <= 1
+
 
 class BaseUser(BaseModel):
     """BaseUser represents an access type. The frontend will include more detailed User info."""

--- a/src/webapp/utilities_test.py
+++ b/src/webapp/utilities_test.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from .utilities import (
     has_access_to_inst_or_err,
     has_full_data_access_or_err,
+    has_at_most_one_school_type,
     uuid_to_str,
     databricksify_inst_name,
 )
@@ -25,6 +26,18 @@ def test_base_user_class_functions():
     assert DATAKINDER.has_full_data_access()
     assert USR.has_full_data_access()
     assert not VIEWER.has_full_data_access()
+
+
+def test_has_at_most_one_school_type() -> None:
+    """Test mutual exclusivity helper: at most one of pdp_id, edvise_id, legacy_id may be set."""
+    assert has_at_most_one_school_type(None, None, None) is True
+    assert has_at_most_one_school_type("pdp1", None, None) is True
+    assert has_at_most_one_school_type(None, "edvise1", None) is True
+    assert has_at_most_one_school_type(None, None, "legacy1") is True
+    assert has_at_most_one_school_type("pdp1", "edvise1", None) is False
+    assert has_at_most_one_school_type("pdp1", None, "legacy1") is False
+    assert has_at_most_one_school_type(None, "edvise1", "legacy1") is False
+    assert has_at_most_one_school_type("pdp1", "edvise1", "legacy1") is False
 
 
 def test_has_access_to_inst_or_err():

--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -74,8 +74,8 @@ def validate_file_reader(
         allowed_schema: List of model names to validate against.
         base_schema: Base schema dict (e.g. base.data_models).
         inst_schema: Optional extension schema with institutions.* blocks.
-        institution_id: Key into inst_schema["institutions"]: "edvise", "pdp", or
-            institution UUID for custom. Default "pdp" for backward compatibility.
+        institution_id: Key into inst_schema["institutions"]: "edvise", "pdp",
+            "legacy" (any-format), or institution UUID for custom. Default "pdp".
         institution_identifier: Optional institution identifier (e.g. UUID) for display/context.
         pdp_cohort_converter_func: Optional custom PDP cohort converter (school-specific).
         pdp_course_converter_func: Optional custom PDP course converter (school-specific).
@@ -179,7 +179,7 @@ def get_extension_model_columns_only(
 ) -> Dict[str, dict]:
     """
     Return only the extension columns for the given institution and model (no base).
-    Used for PDP and Edvise so we do not pull in base columns that don't match the repo schema.
+    Used for PDP and Edvise Schema (ES) so we do not pull in base columns that don't match the repo schema.
     """
     if not extension_schema:
         return {}
@@ -1004,6 +1004,86 @@ def _validate_pdp_with_edvise_read(
 # --------------------------------------------------------------------------- #
 
 
+def _validate_legacy_any_format(
+    filename: Src,
+    enc: str,
+    models: Union[str, List[str], None],
+) -> Dict[str, Any]:
+    """
+    Legacy institutions: accept any CSV format (encoding check only, no schema).
+
+    Reads the file as CSV with no column or type checks; returns the DataFrame
+    as-is as normalized_df so it can be written to validated/.
+
+    Args:
+        filename: Path or file-like object for the CSV.
+        enc: Encoding already sniffed for the file.
+        models: Allowed schema names (e.g. ["STUDENT"]); used for response only.
+
+    Returns:
+        Dict with validation_status, schemas, missing_optional, unknown_extra_columns,
+        and normalized_df (the DataFrame as read, or empty if read failed/empty).
+
+    Raises:
+        HardValidationError: If the file cannot be read or parsed as CSV, or if
+            column names indicate PII (e.g. email, ssn, first_name); such files
+            are rejected before being written to raw/ or validated/.
+    """
+    if models is None:
+        model_list: List[str] = ["UNKNOWN"]
+    elif isinstance(models, str):
+        model_list = [models]
+    else:
+        model_list = list(models)
+    if not model_list:
+        model_list = ["UNKNOWN"]
+
+    with _path_for_edvise_read(filename, enc) as path:
+        read_enc = "utf-8" if not isinstance(filename, (str, os.PathLike)) else enc
+        try:
+            df = pd.read_csv(path, encoding=read_enc)
+        except (
+            pd.errors.ParserError,
+            pd.errors.EmptyDataError,
+            UnicodeDecodeError,
+            OSError,
+        ) as e:
+            logger.exception("Legacy CSV read failed: %s", e)
+            raise HardValidationError(
+                schema_errors="Legacy upload: could not read CSV.",
+                failure_cases=[str(e)],
+            ) from e
+    if df is None or not isinstance(df, pd.DataFrame):
+        df = pd.DataFrame()
+
+    # PII check: reject legacy uploads that contain columns indicating PII (before moving to raw/validated).
+    # Run whenever there are columns (including header-only CSVs: df.empty is True for 0 rows).
+    if len(df.columns) > 0:
+        # Lazy import to avoid circular dependency: validation_error_formatter imports from this module.
+        from .validation_error_formatter import _is_pii_column
+
+        pii_columns = [str(c) for c in df.columns if _is_pii_column(str(c))]
+        if pii_columns:
+            logger.warning(
+                "Legacy upload rejected: PII columns detected: %s", pii_columns
+            )
+            raise HardValidationError(
+                schema_errors=(
+                    "Legacy upload: file contains columns that may contain personally identifiable information (PII). "
+                    "Please remove or de-identify these columns before uploading."
+                ),
+                failure_cases=pii_columns,
+            )
+
+    return {
+        "validation_status": "passed",
+        "schemas": model_list,
+        "missing_optional": [],
+        "unknown_extra_columns": [],
+        "normalized_df": df,
+    }
+
+
 def validate_dataset(
     filename: Src,
     base_schema: dict,
@@ -1021,6 +1101,7 @@ def validate_dataset(
     (if applicable) or JSON-based validation. Returns dict with validation_status,
     schemas, normalized_df (or None if empty merged_specs). Raises HardValidationError
     on failure; UnicodeError if encoding is not UTF-8/UTF-16/UTF-32.
+    Legacy institutions (institution_id=="legacy"): accept any format (encoding + CSV read only).
 
     For PDP uploads, optional pdp_cohort_converter_func and pdp_course_converter_func
     allow schools to supply custom converters (e.g. from config); if None, edvise
@@ -1031,6 +1112,9 @@ def validate_dataset(
     except UnicodeError as ex:
         raise HardValidationError(schema_errors="decode_error", failure_cases=[str(ex)])
     _reset_to_start_if_possible(filename)
+
+    if institution_id == "legacy":
+        return _validate_legacy_any_format(filename, enc, models)
 
     model_list, merged_specs = _compute_model_list_and_merged_specs(
         base_schema, ext_schema, institution_id, models

--- a/src/webapp/validation_error_formatter.py
+++ b/src/webapp/validation_error_formatter.py
@@ -66,7 +66,7 @@ PII_MEDIUM_RISK_INDICATORS = {
     "middle_name",
     "full_name",
     "address",
-    "student_id",  # Even if de-identified, treat as sensitive
+    # Note: student_id is excluded; it is a standard de-identified identifier for all institution types.
     # Note: Patterns like "student_name", "employee_name", "guardian_name" will
     # be caught because they contain "name" as a token, but we check
     # false positives first
@@ -75,6 +75,7 @@ PII_MEDIUM_RISK_INDICATORS = {
 # Common non-PII column name patterns that should NOT be flagged
 # These are compound names where a PII indicator appears but isn't actually PII
 PII_FALSE_POSITIVE_PATTERNS = {
+    "student_id",  # Standard de-identified identifier for all institution types
     "course_name",
     "school_name",
     "district_name",
@@ -1296,7 +1297,7 @@ def _format_check_error(check_type: str, spec: dict, value: Any) -> str:
     if base_check_type == "nullable":
         return "Value validation failed"
 
-    # PDP/Edvise schema check names (same validation as edvise repo)
+    # PDP/Edvise Schema (ES) check names (same validation as edvise repo)
     if base_check_type in PDP_EDVISE_CHECK_MESSAGES:
         return PDP_EDVISE_CHECK_MESSAGES[base_check_type]
 

--- a/src/webapp/validation_error_formatter_test.py
+++ b/src/webapp/validation_error_formatter_test.py
@@ -190,10 +190,10 @@ def test_sanitize_string_non_string_input() -> None:
 
 
 def test_is_pii_column_student_id() -> None:
-    """Test PII detection for student_id."""
-    assert _is_pii_column("student_id") is True
-    assert _is_pii_column("Student_ID") is True
-    assert _is_pii_column("STUDENT_ID") is True
+    """student_id is a standard de-identified identifier; not treated as PII."""
+    assert _is_pii_column("student_id") is False
+    assert _is_pii_column("Student_ID") is False
+    assert _is_pii_column("STUDENT_ID") is False
 
 
 def test_is_pii_column_email() -> None:
@@ -222,6 +222,7 @@ def test_is_pii_column_ssn() -> None:
 def test_is_pii_column_non_pii() -> None:
     """Test PII detection returns False for non-PII columns."""
     assert _is_pii_column("grade") is False
+    assert _is_pii_column("student_id") is False  # standard de-identified identifier
     assert _is_pii_column("course_name") is False
     assert _is_pii_column("credits") is False
     assert _is_pii_column("term") is False
@@ -241,7 +242,6 @@ def test_is_pii_column_medium_risk_token_matching() -> None:
     assert _is_pii_column("first_name") is True
     assert _is_pii_column("last_name") is True
     assert _is_pii_column("full_name") is True
-    assert _is_pii_column("student_id") is True
     assert _is_pii_column("home_address") is True
 
     # These should NOT match (false positive prevention)
@@ -719,7 +719,7 @@ def test_format_check_error_not_nullable() -> None:
 
 
 def test_format_check_error_pdp_check_num_institutions() -> None:
-    """PDP/Edvise schema check names get human-readable messages."""
+    """PDP/Edvise Schema (ES) check names get human-readable messages."""
     spec: Dict[str, Any] = {}
     result = _format_check_error("check_num_institutions", spec, None)
     assert "institution" in result.lower()
@@ -911,13 +911,13 @@ def test_format_column_validation_errors(
 def test_format_column_validation_errors_pii_masking(
     error_with_pii: HardValidationError,
 ) -> None:
-    """Test PII masking in column validation errors."""
+    """Test PII masking in column validation errors (email is PII and masked; student_id is not)."""
     errors = [
-        {"row": 1, "check": "str_length", "value": "STU-12345-ABCDEF"},
+        {"row": 2, "check": "matches", "value": "john.doe@example.com"},
     ]
-    result = _format_column_validation_errors("student_id", errors, error_with_pii)
+    result = _format_column_validation_errors("email", errors, error_with_pii)
     assert len(result) > 0
-    assert "STU-12345-ABCDEF" not in result[0]
+    assert "john.doe@example.com" not in result[0]
     assert "masked for privacy" in result[0]
     assert "*" in result[0]
 
@@ -1061,11 +1061,12 @@ def test_format_validation_error_failure_cases(
 def test_format_validation_error_pii_masking(
     error_with_pii: HardValidationError,
 ) -> None:
-    """Test PII masking in formatted error."""
+    """Test PII masking: email is masked; student_id is not PII so its value is shown."""
     result = format_validation_error(error_with_pii)
-    assert "STU-12345-ABCDEF" not in result
     assert "john.doe@example.com" not in result
     assert "masked for privacy" in result
+    # student_id is a standard de-identified identifier, so its value is not masked
+    assert "STU-12345-ABCDEF" in result
 
 
 def test_format_validation_error_decode_error() -> None:

--- a/src/webapp/validation_pdp_edvise.py
+++ b/src/webapp/validation_pdp_edvise.py
@@ -220,7 +220,7 @@ def _convert_schema_errors_to_hard_validation_error(
     if schema_errors is None:
         schema_errors = str(err) if err else None
     logger.error(
-        "PDP/Edvise schema validation failed: missing_required=%s, failure_cases_count=%s",
+        "PDP/Edvise Schema (ES) validation failed: missing_required=%s, failure_cases_count=%s",
         missing_required,
         len(normalized_failure_cases),
     )
@@ -266,7 +266,7 @@ def validate_dataframe_with_edvise_schema(
     HardValidationError = _get_hard_validation_error_class()
     if df is None or df.empty:
         raise HardValidationError(
-            schema_errors="PDP/Edvise schema validation failed: empty or missing DataFrame",
+            schema_errors="PDP/Edvise Schema (ES) validation failed: empty or missing DataFrame",
             raw_to_canon=raw_to_canon,
             canon_to_raw=canon_to_raw,
             merged_specs=merged_specs,

--- a/src/webapp/validation_pdp_edvise_test.py
+++ b/src/webapp/validation_pdp_edvise_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for PDP/Edvise schema validation (same validation as edvise repo)."""
+"""Unit tests for PDP/Edvise Schema (ES) validation (same validation as edvise repo)."""
 
 import pandas as pd
 from typing import Any, Dict, cast

--- a/src/webapp/validation_test.py
+++ b/src/webapp/validation_test.py
@@ -190,6 +190,123 @@ def test_validate_file_reader_uses_institution_id_for_extension_block(
         assert result_with_id["validation_status"] == "passed"
 
 
+def test_validate_file_reader_legacy_accepts_any_format(tmp_path: Path) -> None:
+    """Legacy institutions: any CSV format is accepted (encoding + read only, no schema)."""
+    csv_path = tmp_path / "any_columns.csv"
+    csv_path.write_text("a,b,c\n1,2,hello\n3,4,world", encoding="utf-8")
+    result = validate_file_reader(
+        str(csv_path),
+        ["STUDENT"],
+        base_schema=MOCK_BASE_SCHEMA,
+        inst_schema=None,
+        institution_id="legacy",
+    )
+    assert result["validation_status"] == "passed"
+    assert result["schemas"] == ["STUDENT"]
+    assert result["normalized_df"] is not None
+    df = result["normalized_df"]
+    assert list(df.columns) == ["a", "b", "c"]
+    assert len(df) == 2
+
+
+def test_validate_file_reader_legacy_accepts_student_id_column(tmp_path: Path) -> None:
+    """Legacy institutions: student_id is an allowed de-identified identifier column."""
+    csv_path = tmp_path / "with_student_id.csv"
+    csv_path.write_text(
+        "student_id,grade,term\nabc123,A,Fall\nxyz789,B,Spring", encoding="utf-8"
+    )
+    result = validate_file_reader(
+        str(csv_path),
+        ["STUDENT"],
+        base_schema=MOCK_BASE_SCHEMA,
+        inst_schema=None,
+        institution_id="legacy",
+    )
+    assert result["validation_status"] == "passed"
+    assert list(result["normalized_df"].columns) == ["student_id", "grade", "term"]
+
+
+def test_validate_file_reader_legacy_header_only_csv_passes(tmp_path: Path) -> None:
+    """Legacy institutions: CSV with only a header row (no data) passes; PII check runs on column names only."""
+    csv_path = tmp_path / "header_only.csv"
+    csv_path.write_text("col_a,col_b,col_c\n", encoding="utf-8")
+    result = validate_file_reader(
+        str(csv_path),
+        ["STUDENT"],
+        base_schema=MOCK_BASE_SCHEMA,
+        inst_schema=None,
+        institution_id="legacy",
+    )
+    assert result["validation_status"] == "passed"
+    df = result["normalized_df"]
+    assert list(df.columns) == ["col_a", "col_b", "col_c"]
+    assert len(df) == 0
+
+
+def test_validate_file_reader_legacy_rejects_header_only_pii_columns(
+    tmp_path: Path,
+) -> None:
+    """Legacy institutions: header-only CSV with PII column names is rejected (no data rows)."""
+    csv_path = tmp_path / "header_only_pii.csv"
+    csv_path.write_text("email,ssn\n", encoding="utf-8")
+    with pytest.raises(HardValidationError) as exc_info:
+        validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            base_schema=MOCK_BASE_SCHEMA,
+            inst_schema=None,
+            institution_id="legacy",
+        )
+    err = exc_info.value
+    assert "PII" in (err.schema_errors or "")
+    failure_cases = err.failure_cases or []
+    assert "email" in failure_cases
+    assert "ssn" in failure_cases
+
+
+def test_validate_file_reader_legacy_rejects_pii_columns(tmp_path: Path) -> None:
+    """Legacy institutions: files with column names indicating PII are rejected before raw/validated."""
+    csv_path = tmp_path / "with_pii.csv"
+    csv_path.write_text(
+        "id,email,score\n1,user@example.com,85\n2,other@test.org,90", encoding="utf-8"
+    )
+    with pytest.raises(HardValidationError) as exc_info:
+        validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            base_schema=MOCK_BASE_SCHEMA,
+            inst_schema=None,
+            institution_id="legacy",
+        )
+    err = exc_info.value
+    assert "PII" in (err.schema_errors or "")
+    assert "email" in (err.failure_cases or [])
+
+
+def test_validate_file_reader_legacy_rejects_multiple_pii_columns(
+    tmp_path: Path,
+) -> None:
+    """Legacy institutions: all detected PII column names are listed in the error."""
+    csv_path = tmp_path / "multi_pii.csv"
+    csv_path.write_text(
+        "first_name,last_name,grade\nAlice,Smith,A\nBob,Jones,B",
+        encoding="utf-8",
+    )
+    with pytest.raises(HardValidationError) as exc_info:
+        validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            base_schema=MOCK_BASE_SCHEMA,
+            inst_schema=None,
+            institution_id="legacy",
+        )
+    err = exc_info.value
+    assert "PII" in (err.schema_errors or "")
+    failure_cases = err.failure_cases or []
+    assert "first_name" in failure_cases
+    assert "last_name" in failure_cases
+
+
 def test_validate_file_reader_csv_read_failure_raises_hard_validation_error(
     tmp_csv_file: str,
 ) -> None:


### PR DESCRIPTION
<!-- Provide a brief description of your changes in the title above. -->

# feat: legacy school type with any-format uploads, PII check, and Edvise Schema (ES) naming

## changes

- **Institutions API**
  - Add `legacy_id` to institution model and create/update flows. Enforce mutual exclusivity: at most one of `pdp_id`, `edvise_id`, or `legacy_id` per institution via `has_at_most_one_school_type()`.
  - Auto-assign `edvise_id` / `legacy_id` (e.g. `edvise_N`, `legacy_N`) on create when `is_edvise` / `is_legacy` is set and no id provided. Reject create when more than one school type is requested.

- **Validation (data upload)**
  - **Legacy path:** For institutions with `legacy_id`, use `schema_namespace = "legacy"`: any CSV format (encoding + read only, no schema validation), then PII column check before moving to raw/validated. `student_id` is excluded from PII (treated as non-PII).
  - **Legacy + arbitrary filenames:** Fetch institution before filename inference. When the filename does not imply student/course/semester, legacy schools get `allowed_schemas = ["UNKNOWN"]` instead of 422; non-legacy still receive 422 for non-descriptive filenames.
  - **validation_helper refactor:** Split into helpers under 50 lines; add full docstrings (Args/Returns/Raises), early validation (empty file name 422, invalid `inst_id` 404 with logging), and module-level constants for cache TTLs.

- **Naming**
  - Use “Edvise Schema (ES)” in user-facing messages, docstrings, and comments where the schema type (not the product) is meant.

- **Tests**
  - Institutions: explicit `legacy_id` on create, PATCH to add `legacy_id`, bucket/Databricks failures, reject both edvise + legacy.
  - Validation/data: legacy header-only CSV, legacy PII → 400, legacy arbitrary filename → 200 with `file_types: ["UNKNOWN"]`, empty file name → 422, invalid `inst_id` → 404, edvise non-descriptive filename → 422, duplicate validate idempotent.
  - Unit tests for `_infer_allowed_schemas_from_filename` and `_ext_models_set`; utilities test for `has_at_most_one_school_type`.


## context

- **Legacy schools** need to upload CSVs without conforming to PDP/Edvise schema or filename conventions. This branch introduces a dedicated “legacy” institution type and validation path: encoding + CSV read + PII check only, with no schema validation.
- **Arbitrary filenames** for legacy avoid 422s when filenames don’t include keywords like “student” or “course”; those files are stored with schema type `UNKNOWN`. Downstream (EDA, model runs) that require STUDENT/COURSE still behave as before (404/400 when only UNKNOWN is present).
- **PII check** prevents legacy uploads with columns that look like PII (e.g. email, SSN) from being written to raw/validated.
- **Edvise Schema (ES)** naming reduces confusion between the schema type and the product name in API and logs.


## deployment

Before or as part of deploying this branch, the database schema must include the `legacy_id` column on the institution table. If it is not already present, run:

```sql
ALTER TABLE inst ADD COLUMN legacy_id VARCHAR(36) NULL;
```

(This matches `pdp_id` / `edvise_id` in the schema; `VAR_CHAR_LENGTH` is 36 in the codebase.)

## questions
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes institution creation/update rules and the core upload validation flow, including a new bypass path that accepts arbitrary CSVs (gated by `legacy_id`) and new PII-based rejections.
> 
> **Overview**
> Adds **Legacy schools** by introducing `InstTable.legacy_id` and exposing it through institutions read/create/update responses, with enforced mutual exclusivity across `pdp_id`, `edvise_id`, and `legacy_id` plus optional auto-assignment of `edvise_id`/`legacy_id` on create.
> 
> Refactors upload validation routing (`validation_helper`) into smaller helpers, adds stricter input validation (empty filenames, invalid institution IDs), and introduces a legacy validation path (`institution_id="legacy"`) that **skips schema validation**, reads the CSV as-is, and blocks uploads whose column names look like PII.
> 
> Updates documentation/messages to consistently use **“Edvise Schema (ES)”**, adjusts PII detection to treat `student_id` as non-PII, and expands tests/fixtures to cover legacy behavior, new error cases, and updated masking expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f013390c0e8c72b8da1b098681ad4cdbdfa1a21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213450406365275