### PR TITLE
feat: trigger Databricks GCS→bronze sync after file validation (Edvise/Legacy)

### DIFF
--- a/src/webapp/.env.example
+++ b/src/webapp/.env.example
@@ -32,6 +32,9 @@ DATABRICKS_WORKSPACE=""
 DATABRICKS_HOST_URL=""
 # The service account used to read GCP buckets from Databricks.
 DATABRICKS_SERVICE_ACCOUNT_EMAIL=""
+# Optional. Numeric job id for edvise_validated_gcs_to_bronze_sync (from Databricks job URL / API).
+# If unset, the API resolves the job by name and errors if the name is missing or ambiguous.
+# DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID=""
 
 # Datakinders allowed to issue API key. This should be the MINIMUM set. Keep this group small. Pass as a comma separated string structured like so: "abc@dk.org,bcd@dk.org"
 # The initial value set is api_key_initial which is the initial API key, this is needed for one-time setup. You can remove this once the api key table is populated.

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -35,6 +35,61 @@ MEDALLION_LEVELS = ["silver", "gold", "bronze"]
 PDP_INFERENCE_JOB_NAME = "edvise_github_sourced_pdp_inference_pipeline"
 # GCS validated/ → institution bronze_volume/gcs_uploads (edvise bundle job name).
 VALIDATED_BRONZE_SYNC_JOB_NAME = "edvise_validated_gcs_to_bronze_sync"
+# Optional: numeric Databricks job id. If unset, the job is resolved by name (must be unique).
+DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV = "DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID"
+
+
+def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
+    """
+    Return the job id for the GCS→bronze sync job.
+
+    Prefer ``DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID`` when set (stable across renames).
+    Otherwise resolve by ``VALIDATED_BRONZE_SYNC_JOB_NAME``; multiple matches is an error.
+    """
+    raw = (os.environ.get(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV) or "").strip()
+    if raw:
+        if not raw.isdigit():
+            raise ValueError(
+                f"{DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} must be a positive integer "
+                f"(Databricks job id) if set; got {raw!r}."
+            )
+        job_id = int(raw)
+        if job_id <= 0:
+            raise ValueError(
+                f"{DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} must be positive; got {job_id}."
+            )
+        LOGGER.info(
+            "Bronze sync job id from %s=%s",
+            DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV,
+            job_id,
+        )
+        return job_id
+
+    jobs = list(w.jobs.list(name=VALIDATED_BRONZE_SYNC_JOB_NAME))
+    if len(jobs) == 0:
+        raise ValueError(
+            f"Job named {VALIDATED_BRONZE_SYNC_JOB_NAME!r} not found. "
+            f"Deploy the bundle job or set {DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} "
+            "to the numeric job id from the Databricks UI / API."
+        )
+    if len(jobs) > 1:
+        ids = [j.job_id for j in jobs if j.job_id is not None]
+        raise ValueError(
+            f"Multiple ({len(jobs)}) jobs named {VALIDATED_BRONZE_SYNC_JOB_NAME!r}; "
+            f"set {DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} to the correct id. Found job_ids={ids}."
+        )
+    job = jobs[0]
+    if job.job_id is None:
+        raise ValueError(
+            f"Job named {VALIDATED_BRONZE_SYNC_JOB_NAME!r} has no job_id in list response."
+        )
+    job_id = job.job_id
+    LOGGER.info(
+        "Resolved bronze sync job by name %r: job_id=%s",
+        VALIDATED_BRONZE_SYNC_JOB_NAME,
+        job_id,
+    )
+    return job_id
 
 
 class DatabricksInferenceRunRequest(BaseModel):
@@ -307,17 +362,11 @@ class DatabricksControl(BaseModel):
             ) from e
 
         try:
-            job = next(w.jobs.list(name=VALIDATED_BRONZE_SYNC_JOB_NAME), None)
-            if not job or job.job_id is None:
-                raise ValueError(
-                    f"Job '{VALIDATED_BRONZE_SYNC_JOB_NAME}' not found or has no job_id."
-                )
-            job_id = job.job_id
-            LOGGER.info("Resolved job ID for '%s': %s", VALIDATED_BRONZE_SYNC_JOB_NAME, job_id)
+            job_id = _resolve_validated_bronze_sync_job_id(w)
         except Exception as e:
-            LOGGER.exception("Job lookup failed for '%s'.", VALIDATED_BRONZE_SYNC_JOB_NAME)
+            LOGGER.exception("Job resolution failed for GCS→bronze sync.")
             raise ValueError(
-                f"run_validated_gcs_to_bronze_sync(): Failed to find job: {e}"
+                f"run_validated_gcs_to_bronze_sync(): Failed to resolve job: {e}"
             ) from e
 
         db_inst_name = databricksify_inst_name(req.inst_name)

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -33,6 +33,8 @@ MEDALLION_LEVELS = ["silver", "gold", "bronze"]
 
 # The name of the deployed pipeline in Databricks. Must match directly.
 PDP_INFERENCE_JOB_NAME = "edvise_github_sourced_pdp_inference_pipeline"
+# GCS validated/ → institution bronze_volume/gcs_uploads (edvise bundle job name).
+VALIDATED_BRONZE_SYNC_JOB_NAME = "edvise_validated_gcs_to_bronze_sync"
 
 
 class DatabricksInferenceRunRequest(BaseModel):
@@ -49,6 +51,21 @@ class DatabricksInferenceRunRequest(BaseModel):
 
 class DatabricksInferenceRunResponse(BaseModel):
     """Databricks parameters for an inference run."""
+
+    job_run_id: int
+
+
+class DatabricksBronzeSyncRequest(BaseModel):
+    """Parameters to copy validated GCS objects into the institution bronze volume."""
+
+    inst_name: str
+    gcp_bucket_name: str
+    # Full object paths in the bucket, e.g. ["validated/file.csv"].
+    validated_blob_paths: list[str]
+
+
+class DatabricksBronzeSyncResponse(BaseModel):
+    """Result of triggering the bronze sync Databricks job."""
 
     job_run_id: int
 
@@ -260,6 +277,80 @@ class DatabricksControl(BaseModel):
         LOGGER.info(f"Successfully triggered job run. Run ID: {run_id}")
 
         return DatabricksInferenceRunResponse(job_run_id=run_id)
+
+    def run_validated_gcs_to_bronze_sync(
+        self, req: DatabricksBronzeSyncRequest
+    ) -> DatabricksBronzeSyncResponse:
+        """Trigger the job that copies validated/ objects from GCS into bronze_volume/gcs_uploads."""
+        if not req.validated_blob_paths:
+            raise ValueError(
+                "run_validated_gcs_to_bronze_sync: validated_blob_paths must be non-empty."
+            )
+        LOGGER.info(
+            "Triggering GCS→bronze sync for institution: %s (%s objects)",
+            req.inst_name,
+            len(req.validated_blob_paths),
+        )
+        try:
+            w = WorkspaceClient(
+                host=databricks_vars["DATABRICKS_HOST_URL"],
+                google_service_account=gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
+            )
+        except Exception as e:
+            LOGGER.exception(
+                "Failed to create Databricks WorkspaceClient for bronze sync: %s / %s",
+                databricks_vars["DATABRICKS_HOST_URL"],
+                gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
+            )
+            raise ValueError(
+                f"run_validated_gcs_to_bronze_sync(): Workspace client failed: {e}"
+            ) from e
+
+        try:
+            job = next(w.jobs.list(name=VALIDATED_BRONZE_SYNC_JOB_NAME), None)
+            if not job or job.job_id is None:
+                raise ValueError(
+                    f"Job '{VALIDATED_BRONZE_SYNC_JOB_NAME}' not found or has no job_id."
+                )
+            job_id = job.job_id
+            LOGGER.info("Resolved job ID for '%s': %s", VALIDATED_BRONZE_SYNC_JOB_NAME, job_id)
+        except Exception as e:
+            LOGGER.exception("Job lookup failed for '%s'.", VALIDATED_BRONZE_SYNC_JOB_NAME)
+            raise ValueError(
+                f"run_validated_gcs_to_bronze_sync(): Failed to find job: {e}"
+            ) from e
+
+        db_inst_name = databricksify_inst_name(req.inst_name)
+        include_json = json.dumps(req.validated_blob_paths, separators=(",", ":"))
+
+        try:
+            run_job: Any = w.jobs.run_now(
+                job_id,
+                job_parameters={
+                    "gcp_bucket_name": req.gcp_bucket_name,
+                    "databricks_institution_name": db_inst_name,
+                    "DB_workspace": databricks_vars["DATABRICKS_WORKSPACE"],
+                    "sync_run_id": "",
+                    "gcs_source_prefix": "validated/",
+                    "bronze_subdir": "gcs_uploads",
+                    "max_objects": "1000",
+                    "require_at_least_one_file": "true",
+                    "strict_mode": "auto",
+                    "include_blob_paths_json": include_json,
+                },
+            )
+        except Exception as e:
+            LOGGER.exception("Failed to run GCS→bronze sync job.")
+            raise ValueError(
+                f"run_validated_gcs_to_bronze_sync(): Job could not be run: {e}"
+            ) from e
+
+        if not run_job.response or run_job.response.run_id is None:
+            raise ValueError("run_validated_gcs_to_bronze_sync(): No run_id returned.")
+
+        run_id = run_job.response.run_id
+        LOGGER.info("GCS→bronze sync job started. Run ID: %s", run_id)
+        return DatabricksBronzeSyncResponse(job_run_id=run_id)
 
     def delete_inst(self, inst_name: str) -> None:
         """Cleanup tasks required on the Databricks side to delete an institution."""

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -38,6 +38,11 @@ PDP_INFERENCE_JOB_NAME = "edvise_github_sourced_pdp_inference_pipeline"
 VALIDATED_BRONZE_SYNC_JOB_NAME = "edvise_validated_gcs_to_bronze_sync"
 # Optional: numeric Databricks job id. If unset, the job is resolved by name (must be unique).
 DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV = "DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID"
+# Environment-specific Databricks job ids for deployed API environments.
+VALIDATED_BRONZE_SYNC_JOB_IDS_BY_ENV = {
+    "DEV": 1005654397694881,
+    "STAGING": 611181637854021,
+}
 
 # Must match edvise bundle job parameters (github_validated_bronze_sync.yml).
 BRONZE_SYNC_GCS_SOURCE_PREFIX = "validated/"
@@ -106,7 +111,7 @@ def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
     Return the job id for the GCS→bronze sync job.
 
     Prefer ``DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID`` when set (stable across renames).
-    Otherwise resolve by exact name, then by a unique bundle-prefixed name.
+    Otherwise resolve by exact name, deployed environment, then a unique bundle-prefixed name.
     """
     raw = (os.environ.get(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV) or "").strip()
     if raw:
@@ -128,6 +133,10 @@ def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
         return job_id
 
     jobs = list(w.jobs.list(name=VALIDATED_BRONZE_SYNC_JOB_NAME))
+    if len(jobs) == 0:
+        env_job_id = _resolve_validated_bronze_sync_job_id_by_environment()
+        if env_job_id is not None:
+            return env_job_id
     if len(jobs) == 0:
         jobs = _find_validated_bronze_sync_jobs_by_suffix(w)
     if len(jobs) == 0:
@@ -154,6 +163,15 @@ def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
         _databricks_job_name(job) or VALIDATED_BRONZE_SYNC_JOB_NAME,
         job_id,
     )
+    return job_id
+
+
+def _resolve_validated_bronze_sync_job_id_by_environment() -> Optional[int]:
+    """Return the deployed Databricks job id for the current API environment."""
+    env = (os.environ.get("ENV") or "").strip().upper()
+    job_id = VALIDATED_BRONZE_SYNC_JOB_IDS_BY_ENV.get(env)
+    if job_id is not None:
+        LOGGER.info("Bronze sync job id from ENV=%s mapping: job_id=%s", env, job_id)
     return job_id
 
 

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -4,6 +4,7 @@ import os
 import logging
 from pydantic import BaseModel
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import DatabricksError
 from databricks.sdk.service import catalog
 from databricks.sdk.service.sql import (
     Format,
@@ -37,6 +38,65 @@ PDP_INFERENCE_JOB_NAME = "edvise_github_sourced_pdp_inference_pipeline"
 VALIDATED_BRONZE_SYNC_JOB_NAME = "edvise_validated_gcs_to_bronze_sync"
 # Optional: numeric Databricks job id. If unset, the job is resolved by name (must be unique).
 DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV = "DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID"
+
+# Must match edvise bundle job parameters (github_validated_bronze_sync.yml).
+BRONZE_SYNC_GCS_SOURCE_PREFIX = "validated/"
+BRONZE_SYNC_BRONZE_SUBDIR = "gcs_uploads"
+BRONZE_SYNC_MAX_OBJECTS = "1000"
+BRONZE_SYNC_REQUIRE_AT_LEAST_ONE_FILE = "true"
+BRONZE_SYNC_STRICT_MODE = "auto"
+
+
+def _create_databricks_workspace_client(operation: str) -> WorkspaceClient:
+    """
+    Create a Databricks WorkspaceClient using configured host and GCP service account.
+
+    Args:
+        operation: Label for error messages (e.g. ``run_validated_gcs_to_bronze_sync``).
+
+    Returns:
+        Initialized workspace client.
+
+    Raises:
+        ValueError: If client creation fails.
+    """
+    try:
+        return WorkspaceClient(
+            host=databricks_vars["DATABRICKS_HOST_URL"],
+            google_service_account=gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
+        )
+    except (OSError, DatabricksError) as exc:
+        LOGGER.exception(
+            "Failed to create Databricks WorkspaceClient for %s: host=%s service_account=%s",
+            operation,
+            databricks_vars["DATABRICKS_HOST_URL"],
+            gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
+        )
+        raise ValueError(f"{operation}(): Workspace client failed: {exc}") from exc
+
+
+def _run_databricks_job_now(
+    workspace: WorkspaceClient,
+    job_id: int,
+    job_parameters: dict[str, str],
+    operation: str,
+) -> int:
+    """
+    Start a Databricks job run and return the run id.
+
+    Raises:
+        ValueError: If the Jobs API does not return a run id.
+    """
+    try:
+        run_job: Any = workspace.jobs.run_now(job_id, job_parameters=job_parameters)
+    except DatabricksError as exc:
+        LOGGER.exception("Databricks job run failed for %s (job_id=%s).", operation, job_id)
+        raise ValueError(f"{operation}(): Job could not be run: {exc}") from exc
+
+    if not run_job.response or run_job.response.run_id is None:
+        raise ValueError(f"{operation}(): No run_id returned.")
+
+    return int(run_job.response.run_id)
 
 
 def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
@@ -123,6 +183,26 @@ class DatabricksBronzeSyncResponse(BaseModel):
     """Result of triggering the bronze sync Databricks job."""
 
     job_run_id: int
+
+
+def _build_validated_bronze_sync_job_parameters(
+    req: DatabricksBronzeSyncRequest,
+    databricks_institution_name: str,
+) -> dict[str, str]:
+    """Build job_parameters dict for the GCS→bronze sync Databricks job."""
+    include_json = json.dumps(req.validated_blob_paths, separators=(",", ":"))
+    return {
+        "gcp_bucket_name": req.gcp_bucket_name,
+        "databricks_institution_name": databricks_institution_name,
+        "DB_workspace": databricks_vars["DATABRICKS_WORKSPACE"],
+        "sync_run_id": "",
+        "gcs_source_prefix": BRONZE_SYNC_GCS_SOURCE_PREFIX,
+        "bronze_subdir": BRONZE_SYNC_BRONZE_SUBDIR,
+        "max_objects": BRONZE_SYNC_MAX_OBJECTS,
+        "require_at_least_one_file": BRONZE_SYNC_REQUIRE_AT_LEAST_ONE_FILE,
+        "strict_mode": BRONZE_SYNC_STRICT_MODE,
+        "include_blob_paths_json": include_json,
+    }
 
 
 def get_filepath_of_filetype(
@@ -336,68 +416,38 @@ class DatabricksControl(BaseModel):
     def run_validated_gcs_to_bronze_sync(
         self, req: DatabricksBronzeSyncRequest
     ) -> DatabricksBronzeSyncResponse:
-        """Trigger the job that copies validated/ objects from GCS into bronze_volume/gcs_uploads."""
+        """
+        Trigger the job that copies validated/ objects from GCS into bronze_volume/gcs_uploads.
+
+        Args:
+            req: Institution name, bucket, and full GCS object paths under validated/.
+
+        Returns:
+            Response containing the Databricks job run id (run started, not completed).
+
+        Raises:
+            ValueError: If paths are empty, configuration is invalid, or the job cannot start.
+        """
+        operation = "run_validated_gcs_to_bronze_sync"
         if not req.validated_blob_paths:
-            raise ValueError(
-                "run_validated_gcs_to_bronze_sync: validated_blob_paths must be non-empty."
-            )
+            raise ValueError(f"{operation}: validated_blob_paths must be non-empty.")
+
         LOGGER.info(
             "Triggering GCS→bronze sync for institution: %s (%s objects)",
             req.inst_name,
             len(req.validated_blob_paths),
         )
-        try:
-            w = WorkspaceClient(
-                host=databricks_vars["DATABRICKS_HOST_URL"],
-                google_service_account=gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
-            )
-        except Exception as e:
-            LOGGER.exception(
-                "Failed to create Databricks WorkspaceClient for bronze sync: %s / %s",
-                databricks_vars["DATABRICKS_HOST_URL"],
-                gcs_vars["GCP_SERVICE_ACCOUNT_EMAIL"],
-            )
-            raise ValueError(
-                f"run_validated_gcs_to_bronze_sync(): Workspace client failed: {e}"
-            ) from e
 
+        workspace = _create_databricks_workspace_client(operation)
         try:
-            job_id = _resolve_validated_bronze_sync_job_id(w)
-        except Exception as e:
+            job_id = _resolve_validated_bronze_sync_job_id(workspace)
+        except ValueError as exc:
             LOGGER.exception("Job resolution failed for GCS→bronze sync.")
-            raise ValueError(
-                f"run_validated_gcs_to_bronze_sync(): Failed to resolve job: {e}"
-            ) from e
+            raise ValueError(f"{operation}(): Failed to resolve job: {exc}") from exc
 
         db_inst_name = databricksify_inst_name(req.inst_name)
-        include_json = json.dumps(req.validated_blob_paths, separators=(",", ":"))
-
-        try:
-            run_job: Any = w.jobs.run_now(
-                job_id,
-                job_parameters={
-                    "gcp_bucket_name": req.gcp_bucket_name,
-                    "databricks_institution_name": db_inst_name,
-                    "DB_workspace": databricks_vars["DATABRICKS_WORKSPACE"],
-                    "sync_run_id": "",
-                    "gcs_source_prefix": "validated/",
-                    "bronze_subdir": "gcs_uploads",
-                    "max_objects": "1000",
-                    "require_at_least_one_file": "true",
-                    "strict_mode": "auto",
-                    "include_blob_paths_json": include_json,
-                },
-            )
-        except Exception as e:
-            LOGGER.exception("Failed to run GCS→bronze sync job.")
-            raise ValueError(
-                f"run_validated_gcs_to_bronze_sync(): Job could not be run: {e}"
-            ) from e
-
-        if not run_job.response or run_job.response.run_id is None:
-            raise ValueError("run_validated_gcs_to_bronze_sync(): No run_id returned.")
-
-        run_id = run_job.response.run_id
+        job_parameters = _build_validated_bronze_sync_job_parameters(req, db_inst_name)
+        run_id = _run_databricks_job_now(workspace, job_id, job_parameters, operation)
         LOGGER.info("GCS→bronze sync job started. Run ID: %s", run_id)
         return DatabricksBronzeSyncResponse(job_run_id=run_id)
 

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -106,7 +106,7 @@ def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
     Return the job id for the GCS→bronze sync job.
 
     Prefer ``DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID`` when set (stable across renames).
-    Otherwise resolve by ``VALIDATED_BRONZE_SYNC_JOB_NAME``; multiple matches is an error.
+    Otherwise resolve by exact name, then by a unique bundle-prefixed name.
     """
     raw = (os.environ.get(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV) or "").strip()
     if raw:
@@ -129,29 +129,60 @@ def _resolve_validated_bronze_sync_job_id(w: WorkspaceClient) -> int:
 
     jobs = list(w.jobs.list(name=VALIDATED_BRONZE_SYNC_JOB_NAME))
     if len(jobs) == 0:
+        jobs = _find_validated_bronze_sync_jobs_by_suffix(w)
+    if len(jobs) == 0:
         raise ValueError(
-            f"Job named {VALIDATED_BRONZE_SYNC_JOB_NAME!r} not found. "
+            f"Job named {VALIDATED_BRONZE_SYNC_JOB_NAME!r} or a unique bundle-prefixed "
+            f"variant was not found. "
             f"Deploy the bundle job or set {DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} "
             "to the numeric job id from the Databricks UI / API."
         )
     if len(jobs) > 1:
         ids = [j.job_id for j in jobs if j.job_id is not None]
         raise ValueError(
-            f"Multiple ({len(jobs)}) jobs named {VALIDATED_BRONZE_SYNC_JOB_NAME!r}; "
+            f"Multiple ({len(jobs)}) jobs matched {VALIDATED_BRONZE_SYNC_JOB_NAME!r}; "
             f"set {DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV} to the correct id. Found job_ids={ids}."
         )
     job = jobs[0]
     if job.job_id is None:
         raise ValueError(
-            f"Job named {VALIDATED_BRONZE_SYNC_JOB_NAME!r} has no job_id in list response."
+            f"Job matching {VALIDATED_BRONZE_SYNC_JOB_NAME!r} has no job_id in list response."
         )
     job_id = job.job_id
     LOGGER.info(
-        "Resolved bronze sync job by name %r: job_id=%s",
-        VALIDATED_BRONZE_SYNC_JOB_NAME,
+        "Resolved bronze sync job %r: job_id=%s",
+        _databricks_job_name(job) or VALIDATED_BRONZE_SYNC_JOB_NAME,
         job_id,
     )
     return job_id
+
+
+def _databricks_job_name(job: Any) -> Optional[str]:
+    """Return the display name from a Databricks job list item, if present."""
+    settings = getattr(job, "settings", None)
+    name = getattr(settings, "name", None)
+    if isinstance(name, str):
+        return name
+    name = getattr(job, "name", None)
+    if isinstance(name, str):
+        return name
+    return None
+
+
+def _find_validated_bronze_sync_jobs_by_suffix(w: WorkspaceClient) -> list[Any]:
+    """
+    Find a Databricks Asset Bundle dev-mode job with a prefixed display name.
+
+    Development-mode bundle jobs can be named like
+    ``[dev service_principal] edvise_validated_gcs_to_bronze_sync``. Only a
+    single suffix match is accepted by the caller.
+    """
+    suffix = f" {VALIDATED_BRONZE_SYNC_JOB_NAME}"
+    return [
+        job
+        for job in w.jobs.list()
+        if (name := _databricks_job_name(job)) is not None and name.endswith(suffix)
+    ]
 
 
 class DatabricksInferenceRunRequest(BaseModel):

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -90,7 +90,9 @@ def _run_databricks_job_now(
     try:
         run_job: Any = workspace.jobs.run_now(job_id, job_parameters=job_parameters)
     except DatabricksError as exc:
-        LOGGER.exception("Databricks job run failed for %s (job_id=%s).", operation, job_id)
+        LOGGER.exception(
+            "Databricks job run failed for %s (job_id=%s).", operation, job_id
+        )
         raise ValueError(f"{operation}(): Job could not be run: {exc}") from exc
 
     if not run_job.response or run_job.response.run_id is None:

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -98,6 +99,51 @@ def test_resolve_bronze_sync_job_id_by_name_ambiguous_raises(
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
     w = mock.Mock()
     w.jobs.list.return_value = [mock.Mock(job_id=1), mock.Mock(job_id=2)]
+    with pytest.raises(ValueError, match="Multiple"):
+        _resolve_validated_bronze_sync_job_id(w)
+
+
+def test_resolve_bronze_sync_job_id_by_prefixed_bundle_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    job = SimpleNamespace(
+        job_id=123,
+        settings=SimpleNamespace(
+            name="[dev dev_cloudrun_sa] edvise_validated_gcs_to_bronze_sync"
+        ),
+    )
+    w = mock.Mock()
+    w.jobs.list.side_effect = [[], [job]]
+    assert _resolve_validated_bronze_sync_job_id(w) == 123
+    assert w.jobs.list.call_args_list == [
+        mock.call(name="edvise_validated_gcs_to_bronze_sync"),
+        mock.call(),
+    ]
+
+
+def test_resolve_bronze_sync_job_id_by_prefixed_bundle_name_ambiguous_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    w = mock.Mock()
+    w.jobs.list.side_effect = [
+        [],
+        [
+            SimpleNamespace(
+                job_id=1,
+                settings=SimpleNamespace(
+                    name="[dev user_a] edvise_validated_gcs_to_bronze_sync"
+                ),
+            ),
+            SimpleNamespace(
+                job_id=2,
+                settings=SimpleNamespace(
+                    name="[dev user_b] edvise_validated_gcs_to_bronze_sync"
+                ),
+            ),
+        ],
+    ]
     with pytest.raises(ValueError, match="Multiple"):
         _resolve_validated_bronze_sync_job_id(w)
 

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -82,7 +82,9 @@ def test_resolve_bronze_sync_job_id_env_invalid_raises(
         _resolve_validated_bronze_sync_job_id(w)
 
 
-def test_resolve_bronze_sync_job_id_by_name_single(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_bronze_sync_job_id_by_name_single(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
     job = mock.Mock(job_id=99)
     w = mock.Mock()
@@ -137,9 +139,7 @@ def test_run_validated_gcs_to_bronze_sync_calls_run_now_with_bundle_params(
     run_response.response.run_id = 9001
     workspace.jobs.run_now.return_value = run_response
 
-    with mock.patch(
-        "src.webapp.databricks.WorkspaceClient", return_value=workspace
-    ):
+    with mock.patch("src.webapp.databricks.WorkspaceClient", return_value=workspace):
         ctrl = DatabricksControl()
         req = DatabricksBronzeSyncRequest(
             inst_name="My Inst",

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -3,8 +3,15 @@ from unittest import mock
 import pytest
 
 from .databricks import (
+    BRONZE_SYNC_BRONZE_SUBDIR,
+    BRONZE_SYNC_GCS_SOURCE_PREFIX,
+    BRONZE_SYNC_MAX_OBJECTS,
+    BRONZE_SYNC_REQUIRE_AT_LEAST_ONE_FILE,
+    BRONZE_SYNC_STRICT_MODE,
     DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV,
+    DatabricksBronzeSyncRequest,
     DatabricksControl,
+    _build_validated_bronze_sync_job_parameters,
     _resolve_validated_bronze_sync_job_id,
 )
 
@@ -101,3 +108,50 @@ def test_resolve_bronze_sync_job_id_by_name_missing_raises(
     w.jobs.list.return_value = []
     with pytest.raises(ValueError, match="not found"):
         _resolve_validated_bronze_sync_job_id(w)
+
+
+def test_build_validated_bronze_sync_job_parameters_shape() -> None:
+    req = DatabricksBronzeSyncRequest(
+        inst_name="Test School",
+        gcp_bucket_name="bucket-a",
+        validated_blob_paths=["validated/student.csv"],
+    )
+    params = _build_validated_bronze_sync_job_parameters(req, "test_school")
+    assert params["gcp_bucket_name"] == "bucket-a"
+    assert params["databricks_institution_name"] == "test_school"
+    assert params["gcs_source_prefix"] == BRONZE_SYNC_GCS_SOURCE_PREFIX
+    assert params["bronze_subdir"] == BRONZE_SYNC_BRONZE_SUBDIR
+    assert params["max_objects"] == BRONZE_SYNC_MAX_OBJECTS
+    assert params["require_at_least_one_file"] == BRONZE_SYNC_REQUIRE_AT_LEAST_ONE_FILE
+    assert params["strict_mode"] == BRONZE_SYNC_STRICT_MODE
+    assert params["sync_run_id"] == ""
+    assert params["include_blob_paths_json"] == '["validated/student.csv"]'
+
+
+def test_run_validated_gcs_to_bronze_sync_calls_run_now_with_bundle_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, "42")
+    workspace = mock.Mock()
+    run_response = mock.Mock()
+    run_response.response.run_id = 9001
+    workspace.jobs.run_now.return_value = run_response
+
+    with mock.patch(
+        "src.webapp.databricks.WorkspaceClient", return_value=workspace
+    ):
+        ctrl = DatabricksControl()
+        req = DatabricksBronzeSyncRequest(
+            inst_name="My Inst",
+            gcp_bucket_name="my-bucket",
+            validated_blob_paths=["validated/foo.csv"],
+        )
+        resp = ctrl.run_validated_gcs_to_bronze_sync(req)
+
+    assert resp.job_run_id == 9001
+    workspace.jobs.run_now.assert_called_once()
+    run_args, run_kwargs = workspace.jobs.run_now.call_args
+    assert run_args[0] == 42
+    params = run_kwargs["job_parameters"]
+    assert params["include_blob_paths_json"] == '["validated/foo.csv"]'
+    assert params["gcs_source_prefix"] == BRONZE_SYNC_GCS_SOURCE_PREFIX

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -1,6 +1,12 @@
+from unittest import mock
+
 import pytest
 
-from .databricks import DatabricksControl
+from .databricks import (
+    DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV,
+    DatabricksControl,
+    _resolve_validated_bronze_sync_job_id,
+)
 
 
 @pytest.fixture
@@ -51,3 +57,47 @@ def test_invalid_regex_is_ignored(ctrl):
 def test_returns_none_when_no_match(ctrl):
     mapping = {"student": "student.csv"}
     assert ctrl.get_key_for_file(mapping, "unknown.csv") is None
+
+
+def test_resolve_bronze_sync_job_id_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, "12345")
+    w = mock.Mock()
+    assert _resolve_validated_bronze_sync_job_id(w) == 12345
+    w.jobs.list.assert_not_called()
+
+
+def test_resolve_bronze_sync_job_id_env_invalid_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, "not-a-number")
+    w = mock.Mock()
+    with pytest.raises(ValueError, match="positive integer"):
+        _resolve_validated_bronze_sync_job_id(w)
+
+
+def test_resolve_bronze_sync_job_id_by_name_single(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    job = mock.Mock(job_id=99)
+    w = mock.Mock()
+    w.jobs.list.return_value = [job]
+    assert _resolve_validated_bronze_sync_job_id(w) == 99
+
+
+def test_resolve_bronze_sync_job_id_by_name_ambiguous_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    w = mock.Mock()
+    w.jobs.list.return_value = [mock.Mock(job_id=1), mock.Mock(job_id=2)]
+    with pytest.raises(ValueError, match="Multiple"):
+        _resolve_validated_bronze_sync_job_id(w)
+
+
+def test_resolve_bronze_sync_job_id_by_name_missing_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    w = mock.Mock()
+    w.jobs.list.return_value = []
+    with pytest.raises(ValueError, match="not found"):
+        _resolve_validated_bronze_sync_job_id(w)

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -87,6 +87,7 @@ def test_resolve_bronze_sync_job_id_by_name_single(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "DEV")
     job = mock.Mock(job_id=99)
     w = mock.Mock()
     w.jobs.list.return_value = [job]
@@ -103,10 +104,32 @@ def test_resolve_bronze_sync_job_id_by_name_ambiguous_raises(
         _resolve_validated_bronze_sync_job_id(w)
 
 
+def test_resolve_bronze_sync_job_id_by_dev_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "DEV")
+    w = mock.Mock()
+    w.jobs.list.return_value = []
+    assert _resolve_validated_bronze_sync_job_id(w) == 1005654397694881
+    w.jobs.list.assert_called_once_with(name="edvise_validated_gcs_to_bronze_sync")
+
+
+def test_resolve_bronze_sync_job_id_by_staging_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "STAGING")
+    w = mock.Mock()
+    w.jobs.list.return_value = []
+    assert _resolve_validated_bronze_sync_job_id(w) == 611181637854021
+
+
 def test_resolve_bronze_sync_job_id_by_prefixed_bundle_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "LOCAL")
     job = SimpleNamespace(
         job_id=123,
         settings=SimpleNamespace(
@@ -126,6 +149,7 @@ def test_resolve_bronze_sync_job_id_by_prefixed_bundle_name_ambiguous_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "LOCAL")
     w = mock.Mock()
     w.jobs.list.side_effect = [
         [],
@@ -152,6 +176,7 @@ def test_resolve_bronze_sync_job_id_by_name_missing_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV, raising=False)
+    monkeypatch.setenv("ENV", "LOCAL")
     w = mock.Mock()
     w.jobs.list.return_value = []
     with pytest.raises(ValueError, match="not found"):

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, date
 from typing import Annotated, Any, Dict, List, Optional, Tuple, Union, cast
 from pydantic import BaseModel, Field
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status, Response
+from fastapi import APIRouter, Depends, HTTPException, status, Response
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
@@ -89,7 +89,7 @@ def _log_validation_trace_json(event: str, **fields: Any) -> None:
 def _bronze_sync_trace_base(
     correlation_id: str, inst_id: str, bucket: str, file_name: str
 ) -> Dict[str, Any]:
-    """Shared fields for GCS→bronze background trace log lines."""
+    """Shared fields for GCS→bronze trace log lines."""
     return {
         "correlation_id": correlation_id,
         "inst_id": inst_id,
@@ -147,7 +147,7 @@ def _attempt_gcs_bronze_sync_trigger(
     trace_base: Dict[str, Any],
     correlation_id: str,
 ) -> None:
-    """Call Databricks to start the bronze sync job and log success (raises ValueError on failure)."""
+    """Call Databricks to start the bronze sync job and log success."""
     sync_resp = databricks_control.run_validated_gcs_to_bronze_sync(
         DatabricksBronzeSyncRequest(
             inst_name=inst_name,
@@ -168,7 +168,7 @@ def _trigger_gcs_bronze_sync_if_applicable(
     databricks_control: DatabricksControl,
     correlation_id: str,
 ) -> None:
-    """Fire-and-forget Databricks job to copy validated/ into bronze (runs in BackgroundTasks)."""
+    """Trigger Databricks job to copy validated/ into bronze without waiting for the copy."""
     trace_base = _bronze_sync_trace_base(correlation_id, inst_id, bucket, file_name)
     _log_validation_trace_json("gcs_bronze_sync_background_start", **trace_base)
 
@@ -187,7 +187,7 @@ def _trigger_gcs_bronze_sync_if_applicable(
             trace_base,
             correlation_id,
         )
-    except ValueError:
+    except Exception:
         _log_bronze_sync_trigger_failed(trace_base, validated_blob_path, correlation_id)
 
 
@@ -1676,7 +1676,6 @@ def validation_helper(
     storage_control: StorageControl,
     sql_session: Session,
     databricks_control: DatabricksControl,
-    background_tasks: BackgroundTasks,
 ) -> Any:
     """Run file validation for an institution and upsert the file record.
 
@@ -1691,7 +1690,7 @@ def validation_helper(
         current_user: Authenticated user; must have access to inst_id.
         storage_control: StorageControl instance for GCS and validate_file.
         sql_session: DB session for institution, schema, and file record.
-        background_tasks: Schedules GCS→Databricks bronze sync after the response.
+        databricks_control: Starts the GCS→Databricks bronze sync after validation.
 
     Returns:
         Dict with name, inst_id, file_types, source, status.
@@ -1764,10 +1763,9 @@ def validation_helper(
         storage_control,
         sess,
     )
-    # GCS validated/ write is complete; schedule Databricks bronze sync so the client
-    # does not wait on job lookup / run_now (Databricks copy runs asynchronously there).
-    background_tasks.add_task(
-        _trigger_gcs_bronze_sync_if_applicable,
+    # GCS validated/ write is complete; start the Databricks run now. The API waits
+    # only for run_now to return a run id, not for cluster startup or file copying.
+    _trigger_gcs_bronze_sync_if_applicable(
         inst.name,
         inst.edvise_id,
         inst.legacy_id,
@@ -1790,7 +1788,6 @@ def validate_file_sftp(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
-    background_tasks: BackgroundTasks,
 ) -> Any:
     """Validate a given file pulled from SFTP. The file_name should be url encoded."""
     file_name = decode_url_piece(file_name)
@@ -1807,7 +1804,6 @@ def validate_file_sftp(
         storage_control,
         sql_session,
         databricks_control,
-        background_tasks,
     )
 
 
@@ -1821,7 +1817,6 @@ def validate_file_manual_upload(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
-    background_tasks: BackgroundTasks,
 ) -> Any:
     """Validate a given file. The file_name should be url encoded."""
 
@@ -1835,7 +1830,6 @@ def validate_file_manual_upload(
         storage_control,
         sql_session,
         databricks_control,
-        background_tasks,
     )
 
 

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -190,6 +190,7 @@ def _trigger_gcs_bronze_sync_if_applicable(
     except ValueError:
         _log_bronze_sync_trigger_failed(trace_base, validated_blob_path, correlation_id)
 
+
 # Cache for EDA data - TTL of 10 minutes (600 seconds)
 # Cache key format: f"{inst_id}:{batch_id}"
 EDA_CACHE_TTL = int(os.getenv("EDA_CACHE_TTL", "600"))  # Default 10 minutes

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -58,6 +58,7 @@ from edvise.data_audit.eda import EdaSummary
 # Set the logging
 logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def _gcs_bronze_sync_skip_reason(
@@ -85,6 +86,78 @@ def _log_validation_trace_json(event: str, **fields: Any) -> None:
     logger.info("%s", json.dumps(payload, default=str, separators=(",", ":")))
 
 
+def _bronze_sync_trace_base(
+    correlation_id: str, inst_id: str, bucket: str, file_name: str
+) -> Dict[str, Any]:
+    """Shared fields for GCS→bronze background trace log lines."""
+    return {
+        "correlation_id": correlation_id,
+        "inst_id": inst_id,
+        "bucket": bucket,
+        "file_name": file_name,
+    }
+
+
+def _log_bronze_sync_skipped(trace_base: Dict[str, Any], skip_reason: str) -> None:
+    _log_validation_trace_json(
+        "gcs_bronze_sync_background_done",
+        **trace_base,
+        outcome="skipped",
+        skip_reason=skip_reason,
+    )
+
+
+def _log_bronze_sync_success(
+    trace_base: Dict[str, Any],
+    validated_blob_path: str,
+    job_run_id: int,
+) -> None:
+    _log_validation_trace_json(
+        "gcs_bronze_sync_background_done",
+        **trace_base,
+        outcome="success",
+        validated_blob_path=validated_blob_path,
+        databricks_job_run_id=job_run_id,
+        databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
+    )
+
+
+def _log_bronze_sync_trigger_failed(
+    trace_base: Dict[str, Any], validated_blob_path: str, correlation_id: str
+) -> None:
+    _log_validation_trace_json(
+        "gcs_bronze_sync_background_done",
+        **trace_base,
+        outcome="trigger_failed",
+        validated_blob_path=validated_blob_path,
+        databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
+    )
+    logger.exception(
+        "Failed to trigger GCS→bronze Databricks job after validation (non-fatal). "
+        "correlation_id=%s",
+        correlation_id,
+    )
+
+
+def _attempt_gcs_bronze_sync_trigger(
+    inst_name: str,
+    bucket: str,
+    validated_blob_path: str,
+    databricks_control: DatabricksControl,
+    trace_base: Dict[str, Any],
+    correlation_id: str,
+) -> None:
+    """Call Databricks to start the bronze sync job and log success (raises ValueError on failure)."""
+    sync_resp = databricks_control.run_validated_gcs_to_bronze_sync(
+        DatabricksBronzeSyncRequest(
+            inst_name=inst_name,
+            gcp_bucket_name=bucket,
+            validated_blob_paths=[validated_blob_path],
+        )
+    )
+    _log_bronze_sync_success(trace_base, validated_blob_path, sync_resp.job_run_id)
+
+
 def _trigger_gcs_bronze_sync_if_applicable(
     inst_name: str,
     edvise_id: Optional[str],
@@ -96,55 +169,26 @@ def _trigger_gcs_bronze_sync_if_applicable(
     correlation_id: str,
 ) -> None:
     """Fire-and-forget Databricks job to copy validated/ into bronze (runs in BackgroundTasks)."""
-    trace_base: Dict[str, Any] = {
-        "correlation_id": correlation_id,
-        "inst_id": inst_id,
-        "bucket": bucket,
-        "file_name": file_name,
-    }
+    trace_base = _bronze_sync_trace_base(correlation_id, inst_id, bucket, file_name)
     _log_validation_trace_json("gcs_bronze_sync_background_start", **trace_base)
 
     skip_reason = _gcs_bronze_sync_skip_reason(edvise_id, legacy_id)
     if skip_reason is not None:
-        _log_validation_trace_json(
-            "gcs_bronze_sync_background_done",
-            **trace_base,
-            outcome="skipped",
-            skip_reason=skip_reason,
-        )
+        _log_bronze_sync_skipped(trace_base, skip_reason)
         return
 
-    blob = f"validated/{file_name}"
+    validated_blob_path = f"validated/{file_name}"
     try:
-        sync_resp = databricks_control.run_validated_gcs_to_bronze_sync(
-            DatabricksBronzeSyncRequest(
-                inst_name=inst_name,
-                gcp_bucket_name=bucket,
-                validated_blob_paths=[blob],
-            )
-        )
-        _log_validation_trace_json(
-            "gcs_bronze_sync_background_done",
-            **trace_base,
-            outcome="success",
-            validated_blob_path=blob,
-            databricks_job_run_id=sync_resp.job_run_id,
-            databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
-        )
-    except Exception:
-        _log_validation_trace_json(
-            "gcs_bronze_sync_background_done",
-            **trace_base,
-            outcome="trigger_failed",
-            validated_blob_path=blob,
-            databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
-        )
-        logger.exception(
-            "Failed to trigger GCS→bronze Databricks job after validation (non-fatal). "
-            "correlation_id=%s",
+        _attempt_gcs_bronze_sync_trigger(
+            inst_name,
+            bucket,
+            validated_blob_path,
+            databricks_control,
+            trace_base,
             correlation_id,
         )
-logger.setLevel(logging.DEBUG)
+    except ValueError:
+        _log_bronze_sync_trigger_failed(trace_base, validated_blob_path, correlation_id)
 
 # Cache for EDA data - TTL of 10 minutes (600 seconds)
 # Cache key format: f"{inst_id}:{batch_id}"

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -1,10 +1,11 @@
 """API functions related to data."""
 
+import json
 import uuid
 from datetime import datetime, date
 from typing import Annotated, Any, Dict, List, Optional, Tuple, Union, cast
 from pydantic import BaseModel, Field
-from fastapi import APIRouter, Depends, HTTPException, status, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status, Response
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
@@ -44,6 +45,7 @@ from ..database import (
 )
 
 from ..databricks import (
+    VALIDATED_BRONZE_SYNC_JOB_NAME,
     DatabricksBronzeSyncRequest,
     DatabricksControl,
 )
@@ -58,40 +60,89 @@ logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
 logger = logging.getLogger(__name__)
 
 
-def _qualifies_for_gcs_bronze_sync(inst: InstTable) -> bool:
+def _gcs_bronze_sync_skip_reason(
+    edvise_id: Optional[str], legacy_id: Optional[str]
+) -> Optional[str]:
     """
-    Edvise- and legacy-type schools: copy validated/ objects to Databricks bronze after
-    validation. PDP-only flows use other pipelines; opt out with env.
+    If sync should not run, return a stable reason code; otherwise None.
+
+    Used for logging (skip_reason when sync is not run).
     """
     if os.environ.get("ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION", "true").lower() not in (
         "1",
         "true",
         "yes",
     ):
-        return False
-    return inst.edvise_id is not None or inst.legacy_id is not None
+        return "env_disabled"
+    if edvise_id is None and legacy_id is None:
+        return "not_edvise_or_legacy"
+    return None
+
+
+def _log_validation_trace_json(event: str, **fields: Any) -> None:
+    """Emit one JSON object per line for log aggregators (Cloud Logging, Datadog, etc.)."""
+    payload: Dict[str, Any] = {"event": event, **fields}
+    logger.info("%s", json.dumps(payload, default=str, separators=(",", ":")))
 
 
 def _trigger_gcs_bronze_sync_if_applicable(
-    inst: InstTable,
+    inst_name: str,
+    edvise_id: Optional[str],
+    legacy_id: Optional[str],
+    inst_id: str,
     file_name: str,
     bucket: str,
     databricks_control: DatabricksControl,
+    correlation_id: str,
 ) -> None:
-    if not _qualifies_for_gcs_bronze_sync(inst):
+    """Fire-and-forget Databricks job to copy validated/ into bronze (runs in BackgroundTasks)."""
+    trace_base: Dict[str, Any] = {
+        "correlation_id": correlation_id,
+        "inst_id": inst_id,
+        "bucket": bucket,
+        "file_name": file_name,
+    }
+    _log_validation_trace_json("gcs_bronze_sync_background_start", **trace_base)
+
+    skip_reason = _gcs_bronze_sync_skip_reason(edvise_id, legacy_id)
+    if skip_reason is not None:
+        _log_validation_trace_json(
+            "gcs_bronze_sync_background_done",
+            **trace_base,
+            outcome="skipped",
+            skip_reason=skip_reason,
+        )
         return
+
     blob = f"validated/{file_name}"
     try:
-        databricks_control.run_validated_gcs_to_bronze_sync(
+        sync_resp = databricks_control.run_validated_gcs_to_bronze_sync(
             DatabricksBronzeSyncRequest(
-                inst_name=inst.name,
+                inst_name=inst_name,
                 gcp_bucket_name=bucket,
                 validated_blob_paths=[blob],
             )
         )
+        _log_validation_trace_json(
+            "gcs_bronze_sync_background_done",
+            **trace_base,
+            outcome="success",
+            validated_blob_path=blob,
+            databricks_job_run_id=sync_resp.job_run_id,
+            databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
+        )
     except Exception:
+        _log_validation_trace_json(
+            "gcs_bronze_sync_background_done",
+            **trace_base,
+            outcome="trigger_failed",
+            validated_blob_path=blob,
+            databricks_job_name=VALIDATED_BRONZE_SYNC_JOB_NAME,
+        )
         logger.exception(
-            "Failed to trigger GCS→bronze Databricks job after validation (non-fatal)."
+            "Failed to trigger GCS→bronze Databricks job after validation (non-fatal). "
+            "correlation_id=%s",
+            correlation_id,
         )
 logger.setLevel(logging.DEBUG)
 
@@ -1580,6 +1631,7 @@ def validation_helper(
     storage_control: StorageControl,
     sql_session: Session,
     databricks_control: DatabricksControl,
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """Run file validation for an institution and upsert the file record.
 
@@ -1594,6 +1646,7 @@ def validation_helper(
         current_user: Authenticated user; must have access to inst_id.
         storage_control: StorageControl instance for GCS and validate_file.
         sql_session: DB session for institution, schema, and file record.
+        background_tasks: Schedules GCS→Databricks bronze sync after the response.
 
     Returns:
         Dict with name, inst_id, file_types, source, status.
@@ -1633,6 +1686,15 @@ def validation_helper(
     allowed_schemas = _infer_allowed_schemas_from_filename(file_name, inst)
     base_schema_id, base_schema, now = _get_validation_base_schema(sess)
     bucket = get_external_bucket_name(inst_id)
+    correlation_id = str(uuid.uuid4())
+    _log_validation_trace_json(
+        "validation_request",
+        correlation_id=correlation_id,
+        inst_id=inst_id,
+        bucket=bucket,
+        file_name=file_name,
+        validation_source=source_str,
+    )
     schema_namespace, updated_inst_schema = _resolve_schema_namespace_and_extension(
         sess,
         inst,
@@ -1657,8 +1719,18 @@ def validation_helper(
         storage_control,
         sess,
     )
-    _trigger_gcs_bronze_sync_if_applicable(
-        inst, file_name, bucket, databricks_control
+    # GCS validated/ write is complete; schedule Databricks bronze sync so the client
+    # does not wait on job lookup / run_now (Databricks copy runs asynchronously there).
+    background_tasks.add_task(
+        _trigger_gcs_bronze_sync_if_applicable,
+        inst.name,
+        inst.edvise_id,
+        inst.legacy_id,
+        inst_id,
+        file_name,
+        bucket,
+        databricks_control,
+        correlation_id,
     )
     return result
 
@@ -1673,6 +1745,7 @@ def validate_file_sftp(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """Validate a given file pulled from SFTP. The file_name should be url encoded."""
     file_name = decode_url_piece(file_name)
@@ -1689,6 +1762,7 @@ def validate_file_sftp(
         storage_control,
         sql_session,
         databricks_control,
+        background_tasks,
     )
 
 
@@ -1702,6 +1776,7 @@ def validate_file_manual_upload(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """Validate a given file. The file_name should be url encoded."""
 
@@ -1715,6 +1790,7 @@ def validate_file_manual_upload(
         storage_control,
         sql_session,
         databricks_control,
+        background_tasks,
     )
 
 

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -43,7 +43,10 @@ from ..database import (
     DocType,
 )
 
-from ..databricks import DatabricksControl
+from ..databricks import (
+    DatabricksBronzeSyncRequest,
+    DatabricksControl,
+)
 from ..gcsdbutils import update_db_from_bucket
 
 from ..gcsutil import StorageControl
@@ -53,6 +56,43 @@ from edvise.data_audit.eda import EdaSummary
 # Set the logging
 logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _qualifies_for_gcs_bronze_sync(inst: InstTable) -> bool:
+    """
+    Edvise- and legacy-type schools: copy validated/ objects to Databricks bronze after
+    validation. PDP-only flows use other pipelines; opt out with env.
+    """
+    if os.environ.get("ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION", "true").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return False
+    return inst.edvise_id is not None or inst.legacy_id is not None
+
+
+def _trigger_gcs_bronze_sync_if_applicable(
+    inst: InstTable,
+    file_name: str,
+    bucket: str,
+    databricks_control: DatabricksControl,
+) -> None:
+    if not _qualifies_for_gcs_bronze_sync(inst):
+        return
+    blob = f"validated/{file_name}"
+    try:
+        databricks_control.run_validated_gcs_to_bronze_sync(
+            DatabricksBronzeSyncRequest(
+                inst_name=inst.name,
+                gcp_bucket_name=bucket,
+                validated_blob_paths=[blob],
+            )
+        )
+    except Exception:
+        logger.exception(
+            "Failed to trigger GCS→bronze Databricks job after validation (non-fatal)."
+        )
 logger.setLevel(logging.DEBUG)
 
 # Cache for EDA data - TTL of 10 minutes (600 seconds)
@@ -1539,6 +1579,7 @@ def validation_helper(
     current_user: BaseUser,
     storage_control: StorageControl,
     sql_session: Session,
+    databricks_control: DatabricksControl,
 ) -> Any:
     """Run file validation for an institution and upsert the file record.
 
@@ -1603,7 +1644,7 @@ def validation_helper(
         base_schema_id,
         file_name,
     )
-    return _run_validation_and_upsert_file_record(
+    result = _run_validation_and_upsert_file_record(
         bucket,
         file_name,
         allowed_schemas,
@@ -1616,6 +1657,10 @@ def validation_helper(
         storage_control,
         sess,
     )
+    _trigger_gcs_bronze_sync_if_applicable(
+        inst, file_name, bucket, databricks_control
+    )
+    return result
 
 
 @router.post(
@@ -1627,6 +1672,7 @@ def validate_file_sftp(
     current_user: Annotated[BaseUser, Depends(get_current_active_user)],
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
+    databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
 ) -> Any:
     """Validate a given file pulled from SFTP. The file_name should be url encoded."""
     file_name = decode_url_piece(file_name)
@@ -1636,7 +1682,13 @@ def validate_file_sftp(
             detail="SFTP validation needs to be done by a datakinder.",
         )
     return validation_helper(
-        "PDP_SFTP", inst_id, file_name, current_user, storage_control, sql_session
+        "PDP_SFTP",
+        inst_id,
+        file_name,
+        current_user,
+        storage_control,
+        sql_session,
+        databricks_control,
     )
 
 
@@ -1649,13 +1701,20 @@ def validate_file_manual_upload(
     current_user: Annotated[BaseUser, Depends(get_current_active_user)],
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
+    databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
 ) -> Any:
     """Validate a given file. The file_name should be url encoded."""
 
     file_name = decode_url_piece(file_name)
 
     return validation_helper(
-        "MANUAL_UPLOAD", inst_id, file_name, current_user, storage_control, sql_session
+        "MANUAL_UPLOAD",
+        inst_id,
+        file_name,
+        current_user,
+        storage_control,
+        sql_session,
+        databricks_control,
     )
 
 

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -905,6 +905,97 @@ EDVISE_INST_UUID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 EDVISE_INST_2_UUID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 EDVISE_SCHEMA_UUID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 LEGACY_INST_UUID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+PDP_ONLY_INST_UUID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+
+
+@pytest.fixture(name="pdp_only_session")
+def pdp_only_session_fixture():
+    """Database setup for PDP-only institution (pdp_id set; no edvise_id or legacy_id)."""
+    engine = sqlalchemy.create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    pdp_schema_doc = {
+        "version": "1.0.0",
+        "institutions": {"pdp": {"data_models": {}}},
+    }
+    try:
+        with sqlalchemy.orm.Session(engine) as session:
+            session.add_all(
+                [
+                    InstTable(
+                        id=PDP_ONLY_INST_UUID,
+                        name="pdp_only_school",
+                        pdp_id="pdp999",
+                        edvise_id=None,
+                        legacy_id=None,
+                        schemas=["STUDENT"],
+                        created_at=DATETIME_TESTING,
+                        updated_at=DATETIME_TESTING,
+                    ),
+                    SchemaRegistryTable(
+                        doc_type=DocType.base,
+                        is_pdp=False,
+                        is_edvise=False,
+                        version_label="1.0.0",
+                        json_doc={"version": "1.0.0", "base": {"data_models": {}}},
+                        is_active=True,
+                        created_at=DATETIME_TESTING,
+                    ),
+                    SchemaRegistryTable(
+                        doc_type=DocType.extension,
+                        is_pdp=True,
+                        is_edvise=False,
+                        version_label="pdp-1.0.0",
+                        json_doc=pdp_schema_doc,
+                        is_active=True,
+                        created_at=DATETIME_TESTING,
+                    ),
+                ]
+            )
+            session.commit()
+            yield session
+    finally:
+        Base.metadata.drop_all(engine)
+
+
+@pytest.fixture(name="pdp_only_client")
+def pdp_only_client_fixture(
+    pdp_only_session: sqlalchemy.orm.Session, monkeypatch: Any
+) -> Any:
+    """Test client for PDP-only institution validation tests."""
+    monkeypatch.setenv("SST_SKIP_EXT_GEN", "1")
+
+    def get_session_override():
+        return pdp_only_session
+
+    def get_current_active_user_override():
+        from ..utilities import AccessType, BaseUser
+
+        return BaseUser(
+            uuid_to_str(USER_UUID),
+            uuid_to_str(PDP_ONLY_INST_UUID),
+            AccessType.MODEL_OWNER,
+            "abc@example.com",
+        )
+
+    def storage_control_override():
+        return MOCK_STORAGE
+
+    def databricks_control_override():
+        return MOCK_DATABRICKS
+
+    app.include_router(router)
+    app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_current_active_user] = get_current_active_user_override
+    app.dependency_overrides[StorageControl] = storage_control_override
+    app.dependency_overrides[DatabricksControl] = databricks_control_override
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
 
 
 @pytest.fixture(name="legacy_session")
@@ -1164,6 +1255,41 @@ def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
     assert sync_req.inst_name == "legacy_school"
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_id") == "legacy"
+
+
+def test_validate_upload_pdp_only_institution_skips_bronze_sync(
+    pdp_only_client: TestClient,
+) -> None:
+    """PDP-only schools do not trigger GCS→bronze sync (Edvise/Legacy pipeline only)."""
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_DATABRICKS.reset_mock()
+
+    response = pdp_only_client.post(
+        "/institutions/"
+        + uuid_to_str(PDP_ONLY_INST_UUID)
+        + "/input/validate-upload/pdp_student_file.csv",
+    )
+
+    assert response.status_code == 200
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
+
+
+def test_validate_upload_skips_bronze_sync_when_env_disabled(
+    edvise_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION=false disables bronze sync for Edvise schools."""
+    monkeypatch.setenv("ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION", "false")
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_DATABRICKS.reset_mock()
+
+    response = edvise_client.post(
+        "/institutions/"
+        + uuid_to_str(EDVISE_INST_UUID)
+        + "/input/validate-upload/edvise_student_file.csv",
+    )
+
+    assert response.status_code == 200
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
 
 
 def test_validate_upload_rejects_empty_file_name(legacy_client: TestClient) -> None:

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -37,8 +37,11 @@ from .data import (
 )
 from fastapi import HTTPException
 from ..gcsutil import StorageControl
+from ..databricks import DatabricksControl
 
 MOCK_STORAGE = mock.Mock()
+MOCK_DATABRICKS = mock.Mock()
+MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.return_value = mock.Mock(job_run_id=1)
 
 UUID_2 = uuid.UUID("9bcbc782-2e71-4441-afa2-7a311024a5ec")
 FILE_UUID_1 = uuid.UUID("f0bb3a20-6d92-4254-afed-6a72f43c562a")
@@ -214,10 +217,14 @@ def client_fixture(session: sqlalchemy.orm.Session, monkeypatch: Any) -> Any:
     def storage_control_override():
         return MOCK_STORAGE
 
+    def databricks_control_override():
+        return MOCK_DATABRICKS
+
     app.include_router(router)
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_active_user] = get_current_active_user_override
     app.dependency_overrides[StorageControl] = storage_control_override
+    app.dependency_overrides[DatabricksControl] = databricks_control_override
 
     client = TestClient(app)
     yield client
@@ -963,10 +970,14 @@ def legacy_client_fixture(
     def storage_control_override():
         return MOCK_STORAGE
 
+    def databricks_control_override():
+        return MOCK_DATABRICKS
+
     app.include_router(router)
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_active_user] = get_current_active_user_override
     app.dependency_overrides[StorageControl] = storage_control_override
+    app.dependency_overrides[DatabricksControl] = databricks_control_override
 
     client = TestClient(app)
     yield client
@@ -1083,10 +1094,14 @@ def edvise_client_fixture(
     def storage_control_override():
         return MOCK_STORAGE
 
+    def databricks_control_override():
+        return MOCK_DATABRICKS
+
     app.include_router(router)
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_active_user] = get_current_active_user_override
     app.dependency_overrides[StorageControl] = storage_control_override
+    app.dependency_overrides[DatabricksControl] = databricks_control_override
 
     client = TestClient(app)
     yield client
@@ -1100,6 +1115,7 @@ def edvise_client_fixture(
 def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
     """Test file upload validation uses Edvise Schema (ES) when edvise_id is set."""
     MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_DATABRICKS.reset_mock()
 
     response = edvise_client.post(
         "/institutions/"
@@ -1118,10 +1134,17 @@ def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_identifier") == uuid_to_str(EDVISE_INST_UUID)
 
+    # GCS → bronze Databricks job triggered for Edvise schools
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
+    sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
+    assert sync_req.validated_blob_paths == ["validated/edvise_student_file.csv"]
+    assert sync_req.inst_name == "edvise_school"
+
 
 def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
     """Test file upload validation uses legacy (any-format) path when legacy_id is set."""
     MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_DATABRICKS.reset_mock()
 
     response = legacy_client.post(
         "/institutions/"
@@ -1135,6 +1158,10 @@ def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
     assert response.json()["inst_id"] == uuid_to_str(LEGACY_INST_UUID)
 
     assert MOCK_STORAGE.validate_file.called
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
+    sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
+    assert sync_req.validated_blob_paths == ["validated/legacy_student_data.csv"]
+    assert sync_req.inst_name == "legacy_school"
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_id") == "legacy"
 
@@ -1611,10 +1638,14 @@ def test_validate_edvise_unauthorized(
     def storage_control_override():
         return MOCK_STORAGE
 
+    def databricks_control_override():
+        return MOCK_DATABRICKS
+
     app.include_router(router)
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_active_user] = get_current_active_user_override
     app.dependency_overrides[StorageControl] = storage_control_override
+    app.dependency_overrides[DatabricksControl] = databricks_control_override
 
     client = TestClient(app)
     try:

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -1292,6 +1292,32 @@ def test_validate_upload_skips_bronze_sync_when_env_disabled(
     MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
 
 
+def test_validate_upload_databricks_trigger_failure_is_non_fatal(
+    edvise_client: TestClient,
+) -> None:
+    """Databricks trigger errors do not fail validation after the file is validated."""
+    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_DATABRICKS.reset_mock()
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.side_effect = RuntimeError(
+        "network failed"
+    )
+    try:
+        response = edvise_client.post(
+            "/institutions/"
+            + uuid_to_str(EDVISE_INST_UUID)
+            + "/input/validate-upload/edvise_student_file.csv",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "edvise_student_file.csv"
+        MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
+    finally:
+        MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.side_effect = None
+        MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.return_value = mock.Mock(
+            job_run_id=1
+        )
+
+
 def test_validate_upload_rejects_empty_file_name(legacy_client: TestClient) -> None:
     """Empty or whitespace-only file name returns 422."""
     # Trailing space in path decodes to " "


### PR DESCRIPTION
# feat(data): trigger Databricks GCS→bronze sync after file validation (Edvise/Legacy)

## Description

After a successful file validation (`POST .../input/validate-upload/{file_name}` or SFTP validate path), the API starts the Databricks job `edvise_validated_gcs_to_bronze_sync` to copy the object from GCS `validated/` into the institution's bronze volume (`gcs_uploads`). Validation and batch creation are unchanged; Databricks trigger failures are logged and do not fail the validation response.

The API waits only for Databricks `jobs.run_now` to accept the run and return a run id. It does **not** wait for cluster startup or the file copy to finish.

**Behavior**

- Runs only for institutions with `edvise_id` or `legacy_id` (PDP-only institutions are skipped).
- Uses existing Databricks auth (`DATABRICKS_HOST_URL`, GCP service account).
- Resolves the job by optional `DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID`, exact job name, DEV/STAGING job ID mapping, or a unique bundle-prefixed job name.
- Structured JSON trace logs: `validation_request`, `gcs_bronze_sync_background_start`, `gcs_bronze_sync_background_done` with `outcome` (`success` | `trigger_failed` | `skipped`) and `correlation_id` for cross-log lookup.

**New / updated**

- `src/webapp/databricks.py` — `run_validated_gcs_to_bronze_sync`, job resolution, bundle-aligned job parameters
- `src/webapp/routers/data.py` — validation-time Databricks trigger in `validation_helper`
- `src/webapp/databricks_test.py`, `src/webapp/routers/data_test.py`
- `src/webapp/.env.example` — documents optional `DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID`

**Kill switch:** `ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION=false` (default: enabled).

## Deployment Readiness*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

**Automated:** `databricks_test.py` (job ID resolution, DEV/STAGING mapping, bundle-prefixed job name resolution, `run_now` params contract); `data_test.py` (Edvise/Legacy trigger paths, PDP-only skip, env disabled, non-fatal Databricks trigger failure).

**Manual (dev):** Deployed feature branch to dev and validated upload as Legacy institution. Confirmed validation succeeded, the API selected the DEV Databricks job id, and the bronze sync job was triggered successfully. Verified expected logs include `outcome:"success"` and `databricks_job_run_id`; corresponding run is visible in Databricks Workflows.

### Deployment Notes

Describe or check:

- [x] No special deployment steps required
- [ ] Special deployment steps required

### Rollback Plan

Describe or check:

- [x] Standard revert is sufficient (`git revert`)

Revert the merge commit. Optionally set `ENABLE_GCS_BRONZE_SYNC_ON_VALIDATION=false` immediately if a hot disable is needed before revert ships. Validation and existing Databricks flows are unaffected.

## Reviewer Guidance / Questions*

- Job parameters are pinned to the edvise bundle contract (`github_validated_bronze_sync.yml`); changes there need a matching API update.
- This intentionally triggers Databricks during the validation request, but only waits for `run_now` to submit the job. It does not wait for the copy itself.
- Databricks trigger errors are non-fatal to validation and are logged as `outcome:"trigger_failed"`.
- Job resolution includes DEV/STAGING deployed job IDs to handle current Databricks bundle naming differences.

## Screenshots / Testing Evidence*

**Expected success log:**

```json
{"event":"validation_request","correlation_id":"...","inst_id":"...","bucket":"...","file_name":"...","validation_source":"MANUAL_UPLOAD"}
{"event":"gcs_bronze_sync_background_start","correlation_id":"...","inst_id":"...","bucket":"...","file_name":"..."}
{"event":"gcs_bronze_sync_background_done","correlation_id":"...","outcome":"success","validated_blob_path":"validated/<file_name>","databricks_job_run_id":123,"databricks_job_name":"edvise_validated_gcs_to_bronze_sync"}
```

**Databricks:** corresponding run visible under Workflows → Jobs for `[dev dev_cloudrun_sa] edvise_validated_gcs_to_bronze_sync`.

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**
- [ ] New roles/permissions are introduced without review and approval by the product manager
- [ ] Hardcoded credentials, secrets, or API keys are present in this code
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy
- [ ] Sensitive data is written to logs
- [ ] Input validation and sanitization is missing
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)
- [ ] No review for common vulnerabilities has been conducted
- [ ] Not tested in a non-production environment
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified
- [ ] Performance impact has not been considered or acceptable
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change
- [ ] Log entries contain sensitive or PII data
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214584270975391