### PR TITLE
feat(api): validate Edvise uploads with repo schemas

### DIFF
--- a/src/webapp/gcsutil.py
+++ b/src/webapp/gcsutil.py
@@ -379,8 +379,8 @@ class StorageControl(BaseModel):
             inst_schema: Optional extension schema with institutions.* blocks.
             institution_id: Key into inst_schema["institutions"]: "edvise", "pdp",
                 or "legacy" (any-format uploads). Default "pdp".
-            institution_identifier: Optional institution ID (e.g. UUID). Reserved for
-                future use; Edvise uses JSON-based validation only (different shape).
+            institution_identifier: Optional institution ID (e.g. UUID). Used by
+                Edvise upload validation for caller context.
 
         Returns:
             List of inferred schema names (e.g. ["STUDENT"]).

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -1116,6 +1116,7 @@ def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
     # Verify that validate_file was called with institution_identifier for Edvise Schema (ES)
     assert MOCK_STORAGE.validate_file.called
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
+    assert call_kwargs.get("institution_id") == "edvise"
     assert call_kwargs.get("institution_identifier") == uuid_to_str(EDVISE_INST_UUID)
 
 

--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -759,9 +759,9 @@ def _compute_model_list_and_merged_specs(
 
 
 # --------------------------------------------------------------------------- #
-# PDP single-model path: edvise read + Pandera validate. Edvise uploads use raw
-# Edvise Pandera schemas directly. Cohort converter defaults to None so PDP
-# validated row sets can differ from batch jobs that use dataio converters.
+# PDP single-model path: edvise read + Pandera validate. Cohort converter defaults
+# to None so PDP validated row sets can differ from batch jobs that use dataio
+# converters.
 # --------------------------------------------------------------------------- #
 
 # Datetime formats to try for PDP course (same order as pdp_data_audit)
@@ -1002,15 +1002,13 @@ def _validate_pdp_with_edvise_read(
     pdp_course_converter_func: PDPConverterFunc = None,
 ) -> Dict[str, Any]:
     """
-    Validate a single-model PDP or Edvise cohort/course file via edvise repo schemas.
+    Validate a single-model PDP cohort or course file via edvise read and Pandera.
 
-    For PDP, writes file-like inputs to a temp path, then calls
-    ``read_raw_pdp_cohort_data`` (STUDENT) or ``_read_pdp_course_edvise`` (COURSE).
-    Cohort rows are only
+    Writes file-like inputs to a temp path, then calls ``read_raw_pdp_cohort_data``
+    (STUDENT) or ``_read_pdp_course_edvise`` (COURSE). Cohort rows are only
     transformed when ``pdp_cohort_converter_func`` is set; batch jobs may still
     filter cohort rows via ``dataio``, so API output rows are not guaranteed to
-    match pipeline output for the same file. Edvise uses the raw Edvise Pandera
-    schema classes directly.
+    match pipeline output for the same file.
 
     Args:
         filename: Path or file-like CSV source.
@@ -1031,14 +1029,6 @@ def _validate_pdp_with_edvise_read(
     """
     _reset_to_start_if_possible(filename)
     model_set = {str(m).strip().upper() for m in model_list if m}
-
-    if institution_id == "edvise":
-        return _validate_edvise_with_repo_schema(
-            filename,
-            enc,
-            model_list,
-            institution_id,
-        )
 
     _validate_pdp_converter_callables(
         pdp_cohort_converter_func, pdp_course_converter_func
@@ -1210,7 +1200,15 @@ def validate_dataset(
     model_list = _model_list_from_models(models)
     # Route PDP/Edvise STUDENT/COURSE to the edvise repo schema path before JSON
     # schema merging so registry extension drift cannot bypass upstream validation.
-    if pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list) is not None:
+    schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
+    if schema_class is not None and institution_id == "edvise":
+        return _validate_edvise_with_repo_schema(
+            filename,
+            enc,
+            model_list,
+            institution_id,
+        )
+    if schema_class is not None:
         return _validate_pdp_with_edvise_read(
             filename,
             enc,

--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -584,49 +584,6 @@ def _read_dataframe_with_specs(
     return df
 
 
-def _try_pdp_repo_validation_and_return(
-    df: pd.DataFrame,
-    model_list: List[str],
-    canon_to_raw: Dict[str, str],
-    raw_to_canon: Dict[str, str],
-    missing_optional: List[str],
-    unknown_extra: List[str],
-    merged_specs: Dict[str, dict],
-    institution_id: str,
-) -> Optional[Dict[str, Any]]:
-    """If a repo schema applies, run it and return result dict; otherwise return None."""
-    schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
-    if schema_class is None:
-        return None
-    validation_df, display_canon_to_raw = (
-        pdp_edvise.rename_pdp_dataframe_to_repo_schema(df, canon_to_raw, model_list)
-    )
-    pdp_edvise.validate_dataframe_with_edvise_schema(
-        validation_df,
-        schema_class,
-        raw_to_canon,
-        display_canon_to_raw,
-        merged_specs,
-    )
-    if missing_optional or unknown_extra:
-        return {
-            "validation_status": "passed_with_soft_errors",
-            "schemas": model_list,
-            "missing_optional": missing_optional,
-            "optional_validation_failures": [],
-            "failure_cases": [],
-            "unknown_extra_columns": unknown_extra,
-            "normalized_df": validation_df,
-        }
-    return {
-        "validation_status": "passed",
-        "schemas": model_list,
-        "missing_optional": [],
-        "unknown_extra_columns": [],
-        "normalized_df": validation_df,
-    }
-
-
 def _validate_optional_columns_json(
     df: pd.DataFrame,
     merged_specs: Dict[str, dict],
@@ -707,21 +664,8 @@ def _run_validation_flow(
     raw_to_canon: Dict[str, str],
     missing_optional: List[str],
     unknown_extra: List[str],
-    institution_id: str,
 ) -> Dict[str, Any]:
-    """Run repo-schema path if applicable; otherwise JSON validation. Returns result dict."""
-    pdp_result = _try_pdp_repo_validation_and_return(
-        df,
-        model_list,
-        canon_to_raw,
-        raw_to_canon,
-        missing_optional,
-        unknown_extra,
-        merged_specs,
-        institution_id,
-    )
-    if pdp_result is not None:
-        return pdp_result
+    """Run JSON validation and return result dict."""
     return _validate_with_json_schemas_return(
         df,
         model_list,
@@ -1250,5 +1194,4 @@ def validate_dataset(
         raw_to_canon,
         missing_optional,
         unknown_extra,
-        institution_id,
     )

--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -594,7 +594,7 @@ def _try_pdp_repo_validation_and_return(
     merged_specs: Dict[str, dict],
     institution_id: str,
 ) -> Optional[Dict[str, Any]]:
-    """If PDP single-model, run repo schema and return result dict; otherwise return None."""
+    """If a repo schema applies, run it and return result dict; otherwise return None."""
     schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
     if schema_class is None:
         return None
@@ -709,7 +709,7 @@ def _run_validation_flow(
     unknown_extra: List[str],
     institution_id: str,
 ) -> Dict[str, Any]:
-    """Run PDP path if applicable; otherwise JSON validation. Returns result dict."""
+    """Run repo-schema path if applicable; otherwise JSON validation. Returns result dict."""
     pdp_result = _try_pdp_repo_validation_and_return(
         df,
         model_list,
@@ -734,6 +734,15 @@ def _run_validation_flow(
     )
 
 
+def _model_list_from_models(models: Union[str, List[str], None]) -> List[str]:
+    """Normalize model input to a list without consulting schema documents."""
+    if models is None:
+        return []
+    if isinstance(models, str):
+        return [models]
+    return list(models)
+
+
 def _compute_model_list_and_merged_specs(
     base_schema: dict,
     ext_schema: Optional[Dict[Any, Any]],
@@ -741,12 +750,7 @@ def _compute_model_list_and_merged_specs(
     models: Union[str, List[str], None],
 ) -> Tuple[List[str], Dict[str, dict]]:
     """Compute model_list and merged_specs from models and schema."""
-    if models is None:
-        model_list = []
-    elif isinstance(models, str):
-        model_list = [models]
-    else:
-        model_list = list(models)
+    model_list = _model_list_from_models(models)
     merged_specs: Dict[str, dict] = {}
     for m in model_list:
         specs = merge_model_columns(base_schema, ext_schema, institution_id, m.lower())
@@ -755,8 +759,9 @@ def _compute_model_list_and_merged_specs(
 
 
 # --------------------------------------------------------------------------- #
-# PDP single-model path: edvise read + Pandera validate. Cohort converter defaults
-# to None so validated row sets can differ from batch jobs that use dataio converters.
+# PDP single-model path: edvise read + Pandera validate. Edvise uploads use raw
+# Edvise Pandera schemas directly. Cohort converter defaults to None so PDP
+# validated row sets can differ from batch jobs that use dataio converters.
 # --------------------------------------------------------------------------- #
 
 # Datetime formats to try for PDP course (same order as pdp_data_audit)
@@ -942,6 +947,52 @@ def _read_pdp_course_edvise(
     raise validation_error
 
 
+def _validate_edvise_with_repo_schema(
+    filename: Src,
+    enc: str,
+    model_list: List[str],
+    institution_id: str,
+) -> Dict[str, Any]:
+    """Validate Edvise Schema uploads with upstream raw Edvise Pandera schemas."""
+    schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
+    if schema_class is None:
+        raise HardValidationError(
+            schema_errors=f"Edvise repo schema expected; got models={model_list}",
+            failure_cases=[],
+        )
+
+    with _path_for_edvise_read(filename, enc) as path:
+        read_enc = "utf-8" if not isinstance(filename, (str, os.PathLike)) else enc
+        try:
+            df = pd.read_csv(path, encoding=read_enc, dtype="string")
+        except (
+            pd.errors.ParserError,
+            pd.errors.EmptyDataError,
+            UnicodeDecodeError,
+            OSError,
+        ) as e:
+            logger.exception("Edvise CSV read failed: %s", e)
+            raise HardValidationError(
+                schema_errors="Edvise upload: could not read CSV.",
+                failure_cases=[str(e)],
+            ) from e
+
+    validated_df = pdp_edvise.validate_dataframe_with_edvise_schema(
+        df,
+        schema_class,
+        raw_to_canon={},
+        canon_to_raw={},
+        merged_specs={},
+    )
+    return {
+        "validation_status": "passed",
+        "schemas": model_list,
+        "missing_optional": [],
+        "unknown_extra_columns": [],
+        "normalized_df": validated_df,
+    }
+
+
 def _validate_pdp_with_edvise_read(
     filename: Src,
     enc: str,
@@ -951,13 +1002,15 @@ def _validate_pdp_with_edvise_read(
     pdp_course_converter_func: PDPConverterFunc = None,
 ) -> Dict[str, Any]:
     """
-    Validate a single-model PDP cohort or course file via edvise read and Pandera.
+    Validate a single-model PDP or Edvise cohort/course file via edvise repo schemas.
 
-    Writes file-like inputs to a temp path, then calls ``read_raw_pdp_cohort_data``
-    (STUDENT) or ``_read_pdp_course_edvise`` (COURSE). Cohort rows are only
+    For PDP, writes file-like inputs to a temp path, then calls
+    ``read_raw_pdp_cohort_data`` (STUDENT) or ``_read_pdp_course_edvise`` (COURSE).
+    Cohort rows are only
     transformed when ``pdp_cohort_converter_func`` is set; batch jobs may still
     filter cohort rows via ``dataio``, so API output rows are not guaranteed to
-    match pipeline output for the same file.
+    match pipeline output for the same file. Edvise uses the raw Edvise Pandera
+    schema classes directly.
 
     Args:
         filename: Path or file-like CSV source.
@@ -978,6 +1031,14 @@ def _validate_pdp_with_edvise_read(
     """
     _reset_to_start_if_possible(filename)
     model_set = {str(m).strip().upper() for m in model_list if m}
+
+    if institution_id == "edvise":
+        return _validate_edvise_with_repo_schema(
+            filename,
+            enc,
+            model_list,
+            institution_id,
+        )
 
     _validate_pdp_converter_callables(
         pdp_cohort_converter_func, pdp_course_converter_func
@@ -1114,8 +1175,9 @@ def validate_dataset(
     Validate a dataset against merged base and optional extension schemas.
 
     Detects encoding, merges institution column specs, then routes to legacy
-    any-format handling, PDP edvise read (single-model STUDENT/COURSE), or
-    JSON Pandera validation. ``institution_id == "legacy"`` skips column schema checks.
+    any-format handling, PDP/Edvise repo schema validation (single-model
+    STUDENT/COURSE), or JSON Pandera validation. ``institution_id == "legacy"``
+    skips column schema checks.
 
     Args:
         filename: CSV path or file-like object.
@@ -1145,6 +1207,19 @@ def validate_dataset(
     if institution_id == "legacy":
         return _validate_legacy_any_format(filename, enc, models)
 
+    model_list = _model_list_from_models(models)
+    # Route PDP/Edvise STUDENT/COURSE to the edvise repo schema path before JSON
+    # schema merging so registry extension drift cannot bypass upstream validation.
+    if pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list) is not None:
+        return _validate_pdp_with_edvise_read(
+            filename,
+            enc,
+            model_list,
+            institution_id,
+            pdp_cohort_converter_func=pdp_cohort_converter_func,
+            pdp_course_converter_func=pdp_course_converter_func,
+        )
+
     model_list, merged_specs = _compute_model_list_and_merged_specs(
         base_schema, ext_schema, institution_id, models
     )
@@ -1156,17 +1231,6 @@ def validate_dataset(
             "unknown_extra_columns": [],
             "normalized_df": None,
         }
-
-    # Route PDP STUDENT/COURSE to edvise read path (cohort converter optional; see section above).
-    if pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list) is not None:
-        return _validate_pdp_with_edvise_read(
-            filename,
-            enc,
-            model_list,
-            institution_id,
-            pdp_cohort_converter_func=pdp_cohort_converter_func,
-            pdp_course_converter_func=pdp_course_converter_func,
-        )
 
     (
         raw_to_canon,

--- a/src/webapp/validation_pdp_edvise.py
+++ b/src/webapp/validation_pdp_edvise.py
@@ -1,11 +1,9 @@
-"""PDP Pandera schemas re-exported from edvise for upload validation.
+"""Pandera schemas re-exported from edvise for upload validation.
 
-Imports ``RawPDPCohortDataSchema`` and ``RawPDPCourseDataSchema`` so PDP uploads use
-the same column and type rules as edvise pipeline audits. Cohort row transforms run
-in ``validation.py`` (optional converter) and can differ from batch ``dataio`` hooks;
-this module only supplies schema classes and helpers.
-
-Non-PDP Edvise institutions use JSON-based validation elsewhere (different columns).
+Imports raw PDP and Edvise schema classes so uploads use the same column and type
+rules as edvise pipeline audits. Cohort row transforms run in ``validation.py``
+(optional converter) and can differ from batch ``dataio`` hooks; this module only
+supplies schema classes and helpers.
 
 Requires the ``edvise`` package (see pyproject.toml).
 """
@@ -23,6 +21,8 @@ from pandera.errors import SchemaError, SchemaErrors
 
 from edvise.data_audit.schemas.raw_cohort import RawPDPCohortDataSchema
 from edvise.data_audit.schemas.raw_course import RawPDPCourseDataSchema
+from edvise.data_audit.schemas.raw_edvise_course import RawEdviseCourseDataSchema
+from edvise.data_audit.schemas.raw_edvise_student import RawEdviseStudentDataSchema
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +34,8 @@ def _get_hard_validation_error_class() -> type:
     return HardValidationError
 
 
-# Institution namespaces that use edvise repo schemas (RawPDPCohortDataSchema / RawPDPCourseDataSchema).
-# Only PDP uses repo validation; Edvise has a different shape and uses JSON-based validation only.
-PDP_EDVISE_NAMESPACES = frozenset({"pdp"})
+# Institution namespaces that use edvise repo schemas for single-model uploads.
+PDP_EDVISE_NAMESPACES = frozenset({"pdp", "edvise"})
 
 
 def rename_pdp_dataframe_to_repo_schema(
@@ -86,16 +85,17 @@ def get_edvise_schema_for_upload(
     Return the edvise repo schema class for this upload, or None.
 
     Use this as the single check: when not None, run that schema and skip JSON
-    Pandera. Only PDP uses repo validation (edvise package required); Edvise
-    institution has a different shape and uses JSON validation only.
+    Pandera. PDP and Edvise single-model STUDENT/COURSE uploads use repo
+    validation (edvise package required).
 
     Args:
-        institution_id: Schema namespace (e.g. "pdp", "edvise", or "legacy"). Only "pdp" uses repo schema.
+        institution_id: Schema namespace (e.g. "pdp", "edvise", or "legacy").
         model_list: Inferred model names from filename (e.g. ["STUDENT"], ["COURSE"]). May be None.
 
     Returns:
         RawPDPCohortDataSchema for PDP+STUDENT, RawPDPCourseDataSchema for PDP+COURSE,
-        or None (non-PDP or multi-model; use JSON-based validation).
+        RawEdviseStudentDataSchema for Edvise+STUDENT, RawEdviseCourseDataSchema for
+        Edvise+COURSE, or None (non-repo-schema or multi-model; use JSON-based validation).
     """
     if not institution_id or not isinstance(institution_id, str):
         return None
@@ -104,10 +104,14 @@ def get_edvise_schema_for_upload(
     if model_list is not None and not isinstance(model_list, list):
         return None
     model_set = {str(m).strip().upper() for m in (model_list or []) if m}
-    if model_set == {"STUDENT"}:
+    if institution_id == "pdp" and model_set == {"STUDENT"}:
         return cast(Optional[type], RawPDPCohortDataSchema)
-    if model_set == {"COURSE"}:
+    if institution_id == "pdp" and model_set == {"COURSE"}:
         return cast(Optional[type], RawPDPCourseDataSchema)
+    if institution_id == "edvise" and model_set == {"STUDENT"}:
+        return cast(Optional[type], RawEdviseStudentDataSchema)
+    if institution_id == "edvise" and model_set == {"COURSE"}:
+        return cast(Optional[type], RawEdviseCourseDataSchema)
     return None
 
 
@@ -120,7 +124,7 @@ def should_use_edvise_schema(
 
 
 def get_edvise_schema_for_models(model_list: List[str]) -> Optional[type]:
-    """Return edvise schema for single-model list (pdp namespace). For tests/callers that don't have institution_id."""
+    """Return PDP edvise schema for single-model lists when callers lack institution_id."""
     return get_edvise_schema_for_upload("pdp", model_list)
 
 
@@ -246,7 +250,7 @@ def validate_dataframe_with_edvise_schema(
     raw_to_canon: Dict[str, str],
     canon_to_raw: Dict[str, str],
     merged_specs: Dict[str, dict],
-) -> None:
+) -> pd.DataFrame:
     """
     Validate a DataFrame with the given edvise schema (cohort or course).
 
@@ -256,10 +260,13 @@ def validate_dataframe_with_edvise_schema(
 
     Args:
         df: DataFrame with canonical column names (from header pass + read).
-        schema_class: RawPDPCohortDataSchema or RawPDPCourseDataSchema.
+        schema_class: RawPDPCohortDataSchema, RawPDPCourseDataSchema, or raw Edvise schema.
         raw_to_canon: Mapping from raw file headers to canonical names.
         canon_to_raw: Mapping from canonical names to raw file headers.
         merged_specs: Merged JSON spec for formatter context.
+
+    Returns:
+        Validated DataFrame returned by the upstream schema class.
 
     Raises:
         HardValidationError: When schema validation fails (missing columns or row-level checks).
@@ -274,7 +281,8 @@ def validate_dataframe_with_edvise_schema(
         )
     try:
         # Lazy=True so all failures are collected in one SchemaErrors.
-        schema_class.validate(df, lazy=True)  # type: ignore[attr-defined]
+        validated_df = schema_class.validate(df, lazy=True)  # type: ignore[attr-defined]
+        return cast(pd.DataFrame, validated_df)
     except (SchemaErrors, SchemaError) as e:
         # Pandera raises SchemaErrors for lazy validation; single failure may raise SchemaError.
         hard = _convert_schema_errors_to_hard_validation_error(

--- a/src/webapp/validation_pdp_edvise_test.py
+++ b/src/webapp/validation_pdp_edvise_test.py
@@ -53,10 +53,10 @@ def test_should_use_edvise_schema_behavior_for_pdp_single_model() -> None:
     assert is_edvise_schema_available() is True
 
 
-def test_should_use_edvise_schema_edvise_namespace_uses_json_validation() -> None:
-    """edvise namespace does not use repo schema; uses JSON-based validation (different shape)."""
-    assert should_use_edvise_schema("edvise", ["STUDENT"]) is False
-    assert should_use_edvise_schema("edvise", ["COURSE"]) is False
+def test_should_use_edvise_schema_edvise_namespace_uses_repo_validation() -> None:
+    """edvise namespace uses upstream raw Edvise schemas for STUDENT and COURSE."""
+    assert should_use_edvise_schema("edvise", ["STUDENT"]) is True
+    assert should_use_edvise_schema("edvise", ["COURSE"]) is True
 
 
 def test_should_use_edvise_schema_normalizes_model_names_to_uppercase() -> None:
@@ -89,6 +89,16 @@ def test_get_edvise_schema_for_models_returns_class_when_available() -> None:
     assert course_schema is not None
     assert cohort_schema.__name__ == "RawPDPCohortDataSchema"
     assert course_schema.__name__ == "RawPDPCourseDataSchema"
+
+
+def test_get_edvise_schema_for_upload_returns_raw_edvise_classes() -> None:
+    """Edvise namespace returns raw Edvise student/course schema classes."""
+    student_schema = get_edvise_schema_for_upload("edvise", ["STUDENT"])
+    course_schema = get_edvise_schema_for_upload("edvise", ["COURSE"])
+    assert student_schema is not None
+    assert course_schema is not None
+    assert student_schema.__name__ == "RawEdviseStudentDataSchema"
+    assert course_schema.__name__ == "RawEdviseCourseDataSchema"
 
 
 def test_get_edvise_schema_for_models_normalizes_lowercase_model_names() -> None:
@@ -171,11 +181,13 @@ def test_extract_missing_required_includes_only_missing_column_checks() -> None:
 
 
 def test_get_edvise_schema_for_upload_single_entry_point() -> None:
-    """get_edvise_schema_for_upload is the single check: None = use JSON path, else run repo schema (PDP only)."""
+    """get_edvise_schema_for_upload is the single check: None = JSON path, else repo schema."""
     assert get_edvise_schema_for_upload("", ["STUDENT"]) is None
     assert get_edvise_schema_for_upload("pdp", ["STUDENT", "COURSE"]) is None
-    assert get_edvise_schema_for_upload("edvise", ["COURSE"]) is None
-    assert get_edvise_schema_for_upload("edvise", ["STUDENT"]) is None
+    assert get_edvise_schema_for_upload("edvise", ["STUDENT", "COURSE"]) is None
+    assert get_edvise_schema_for_upload("edvise", ["SEMESTER"]) is None
+    assert get_edvise_schema_for_upload("edvise", ["COURSE"]) is not None
+    assert get_edvise_schema_for_upload("edvise", ["STUDENT"]) is not None
     assert get_edvise_schema_for_upload("pdp", ["STUDENT"]) is not None
     assert get_edvise_schema_for_upload("pdp", ["COURSE"]) is not None
     assert get_edvise_schema_for_upload("other-uuid", ["STUDENT"]) is None
@@ -191,11 +203,11 @@ def test_get_edvise_schema_for_upload_rejects_non_list_model_list() -> None:
     assert get_edvise_schema_for_upload("pdp", cast(Any, {"STUDENT"})) is None
 
 
-def test_pdp_edvise_namespaces_pdp_only_uses_repo_schema() -> None:
-    """Only PDP uses edvise repo schema; Edvise has a different shape and uses JSON validation."""
+def test_pdp_edvise_namespaces_use_repo_schema() -> None:
+    """PDP and Edvise use upstream repo schemas for supported single-model uploads."""
     assert "pdp" in PDP_EDVISE_NAMESPACES
-    assert "edvise" not in PDP_EDVISE_NAMESPACES
-    assert len(PDP_EDVISE_NAMESPACES) == 1
+    assert "edvise" in PDP_EDVISE_NAMESPACES
+    assert len(PDP_EDVISE_NAMESPACES) == 2
 
 
 # --------------------------------------------------------------------------- #

--- a/src/webapp/validation_pdp_read_path_test.py
+++ b/src/webapp/validation_pdp_read_path_test.py
@@ -181,7 +181,9 @@ def test_validate_file_reader_edvise_routes_before_schema_merge(
                 "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
             },
         ) as mock_edvise_schema,
-        patch("src.webapp.validation._compute_model_list_and_merged_specs") as mock_merge,
+        patch(
+            "src.webapp.validation._compute_model_list_and_merged_specs"
+        ) as mock_merge,
     ):
         result = validate_file_reader(
             str(csv_path),

--- a/src/webapp/validation_pdp_read_path_test.py
+++ b/src/webapp/validation_pdp_read_path_test.py
@@ -121,7 +121,7 @@ def test_validate_file_reader_pdp_course_calls_edvise_read_path(tmp_path: Path) 
 def test_validate_file_reader_edvise_student_calls_repo_schema_path(
     tmp_path: Path,
 ) -> None:
-    """When institution_id is edvise and allowed_schema is [STUDENT], repo schema path is used."""
+    """When institution_id is edvise and allowed_schema is [STUDENT], Edvise repo schema path is used."""
     csv_path = tmp_path / "edvise_student.csv"
     pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
 
@@ -138,7 +138,7 @@ def test_validate_file_reader_edvise_student_calls_repo_schema_path(
             return_value=object(),
         ),
         patch(
-            "src.webapp.validation._validate_pdp_with_edvise_read",
+            "src.webapp.validation._validate_edvise_with_repo_schema",
             return_value={
                 "validation_status": "passed",
                 "schemas": ["STUDENT"],
@@ -146,7 +146,7 @@ def test_validate_file_reader_edvise_student_calls_repo_schema_path(
                 "unknown_extra_columns": [],
                 "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
             },
-        ) as mock_repo_schema,
+        ) as mock_edvise_schema,
     ):
         result = validate_file_reader(
             str(csv_path),
@@ -157,8 +157,8 @@ def test_validate_file_reader_edvise_student_calls_repo_schema_path(
         )
         assert result["validation_status"] == "passed"
         assert result["schemas"] == ["STUDENT"]
-        mock_repo_schema.assert_called_once()
-        call_args = mock_repo_schema.call_args[0]
+        mock_edvise_schema.assert_called_once()
+        call_args = mock_edvise_schema.call_args[0]
         assert call_args[2] == ["STUDENT"]
         assert call_args[3] == "edvise"
 
@@ -170,16 +170,19 @@ def test_validate_file_reader_edvise_routes_before_schema_merge(
     csv_path = tmp_path / "edvise_student.csv"
     pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
 
-    with patch(
-        "src.webapp.validation._validate_pdp_with_edvise_read",
-        return_value={
-            "validation_status": "passed",
-            "schemas": ["STUDENT"],
-            "missing_optional": [],
-            "unknown_extra_columns": [],
-            "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
-        },
-    ) as mock_repo_schema:
+    with (
+        patch(
+            "src.webapp.validation._validate_edvise_with_repo_schema",
+            return_value={
+                "validation_status": "passed",
+                "schemas": ["STUDENT"],
+                "missing_optional": [],
+                "unknown_extra_columns": [],
+                "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
+            },
+        ) as mock_edvise_schema,
+        patch("src.webapp.validation._compute_model_list_and_merged_specs") as mock_merge,
+    ):
         result = validate_file_reader(
             str(csv_path),
             ["STUDENT"],
@@ -189,7 +192,8 @@ def test_validate_file_reader_edvise_routes_before_schema_merge(
         )
 
     assert result["validation_status"] == "passed"
-    mock_repo_schema.assert_called_once()
+    mock_edvise_schema.assert_called_once()
+    mock_merge.assert_not_called()
 
 
 def test_validate_edvise_with_repo_schema_preserves_string_values(

--- a/src/webapp/validation_pdp_read_path_test.py
+++ b/src/webapp/validation_pdp_read_path_test.py
@@ -18,6 +18,7 @@ from src.webapp.validation import (
     HardValidationError,
     _path_for_edvise_read,
     _read_pdp_course_edvise,
+    _validate_edvise_with_repo_schema,
     _validate_pdp_with_edvise_read,
     validate_file_reader,
 )
@@ -115,6 +116,123 @@ def test_validate_file_reader_pdp_course_calls_edvise_read_path(tmp_path: Path) 
         assert result["schemas"] == ["COURSE"]
         mock_pdp.assert_called_once()
         assert mock_pdp.call_args[0][2] == ["COURSE"]
+
+
+def test_validate_file_reader_edvise_student_calls_repo_schema_path(
+    tmp_path: Path,
+) -> None:
+    """When institution_id is edvise and allowed_schema is [STUDENT], repo schema path is used."""
+    csv_path = tmp_path / "edvise_student.csv"
+    pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
+
+    with (
+        patch(
+            "src.webapp.validation._compute_model_list_and_merged_specs",
+            return_value=(
+                ["STUDENT"],
+                {"learner_id": {"dtype": "string", "required": True}},
+            ),
+        ),
+        patch(
+            "src.webapp.validation.pdp_edvise.get_edvise_schema_for_upload",
+            return_value=object(),
+        ),
+        patch(
+            "src.webapp.validation._validate_pdp_with_edvise_read",
+            return_value={
+                "validation_status": "passed",
+                "schemas": ["STUDENT"],
+                "missing_optional": [],
+                "unknown_extra_columns": [],
+                "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
+            },
+        ) as mock_repo_schema,
+    ):
+        result = validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            base_schema={"base": {"data_models": {}}},
+            inst_schema={"institutions": {"edvise": {"data_models": {}}}},
+            institution_id="edvise",
+        )
+        assert result["validation_status"] == "passed"
+        assert result["schemas"] == ["STUDENT"]
+        mock_repo_schema.assert_called_once()
+        call_args = mock_repo_schema.call_args[0]
+        assert call_args[2] == ["STUDENT"]
+        assert call_args[3] == "edvise"
+
+
+def test_validate_file_reader_edvise_routes_before_schema_merge(
+    tmp_path: Path,
+) -> None:
+    """Edvise repo validation should not depend on populated JSON schema docs."""
+    csv_path = tmp_path / "edvise_student.csv"
+    pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
+
+    with patch(
+        "src.webapp.validation._validate_pdp_with_edvise_read",
+        return_value={
+            "validation_status": "passed",
+            "schemas": ["STUDENT"],
+            "missing_optional": [],
+            "unknown_extra_columns": [],
+            "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
+        },
+    ) as mock_repo_schema:
+        result = validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            base_schema={"base": {"data_models": {}}},
+            inst_schema={"institutions": {"edvise": {"data_models": {}}}},
+            institution_id="edvise",
+        )
+
+    assert result["validation_status"] == "passed"
+    mock_repo_schema.assert_called_once()
+
+
+def test_validate_edvise_with_repo_schema_preserves_string_values(
+    tmp_path: Path,
+) -> None:
+    """Edvise CSV loading preserves leading zeros before Pandera coercion."""
+    csv_path = tmp_path / "edvise_student.csv"
+    csv_path.write_text("learner_id,entry_year\n00123,2024\n")
+    schema_class = object()
+    captured_df: pd.DataFrame | None = None
+
+    def capture_validation_df(
+        df: pd.DataFrame,
+        *args: object,
+        **kwargs: object,
+    ) -> pd.DataFrame:
+        nonlocal captured_df
+        captured_df = df
+        return df
+
+    with (
+        patch(
+            "src.webapp.validation.pdp_edvise.get_edvise_schema_for_upload",
+            return_value=schema_class,
+        ),
+        patch(
+            "src.webapp.validation.pdp_edvise.validate_dataframe_with_edvise_schema",
+            side_effect=capture_validation_df,
+        ) as mock_validate,
+    ):
+        result = _validate_edvise_with_repo_schema(
+            str(csv_path),
+            enc="utf-8",
+            model_list=["STUDENT"],
+            institution_id="edvise",
+        )
+
+    assert result["validation_status"] == "passed"
+    assert captured_df is not None
+    assert captured_df.loc[0, "learner_id"] == "00123"
+    assert captured_df["learner_id"].dtype.name == "string"
+    mock_validate.assert_called_once()
+    assert mock_validate.call_args[0][1] is schema_class
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

Routes Edvise `STUDENT` and `COURSE` upload validation through the upstream `edvise` Pandera schemas, matching the existing PDP repo-schema validation pattern.

## Deployment Readiness*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

Validated locally with:

`uv run pytest src/webapp/validation_pdp_read_path_test.py src/webapp/validation_pdp_edvise_test.py src/webapp/routers/data_test.py -q`

`uv run pytest src/webapp -q`

Also deployed branch to dev and smoke-tested fake valid/invalid Edvise student and course CSVs successfully

### Deployment Notes

Describe or check:

- [x] No special deployment steps required

### Rollback Plan

Describe or check:

- [x] Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions*

Please focus review on the Edvise upload validation routing in `src/webapp/validation.py` and schema selection in `src/webapp/validation_pdp_edvise.py`.

## Screenshots / Testing Evidence*

- Focused validation/router suite: `88 passed`
- Full webapp suite: `336 passed`

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213317050994443