### PR TITLE
fix(ci): deploy webapp to Terraform-managed Cloud Run service

### DIFF
--- a/cloudbuild-webapp.yaml
+++ b/cloudbuild-webapp.yaml
@@ -2,7 +2,6 @@
 # Each trigger sets _REGION and _ENVIRONMENT; deploys Cloud Run service "${_ENVIRONMENT}-webapp".
 substitutions:
   _REGION: us-east4
-  _SERVICE: edvise-api
 steps:
   - name: ghcr.io/astral-sh/uv:debian
     entrypoint: bash
@@ -34,7 +33,7 @@ steps:
     args:
       - run
       - deploy
-      - "${_SERVICE}"
+      - "${_ENVIRONMENT}-webapp"
       - "--image"
       - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:$COMMIT_SHA"
       - "--region"


### PR DESCRIPTION
The sync from main targeted a bare edvise-api service without ENV_FILE_PATH and secret mounts, causing startup failures on develop deploys.

## Description

## Asana Task
[EDVISEBUILD-5033
](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1215785632336192?focus=true)
## Deployment Readiness\*

### Testing

Describe or check:

- [ ] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required
- [x] Rebuild on dev cloud build
 
### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional