### PR TITLE
feat: creating `is_genai_institution` parameter to feed into genai/edvise inference job for SSoT

### DIFF
--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -705,7 +705,9 @@ class DatabricksControl(BaseModel):
                     "gcp_bucket_name": req.gcp_external_bucket_name,
                     "datakind_notification_email": req.email,
                     "DK_CC_EMAIL": req.email,
-                    "is_genai_institution": "true" if req.is_genai_institution else "false",
+                    "is_genai_institution": "true"
+                    if req.is_genai_institution
+                    else "false",
                 },
             )
             LOGGER.info(

--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -343,6 +343,8 @@ class DatabricksSharedInferenceRunRequest(BaseModel):
     # The email where notifications will get sent.
     email: str = ""
     gcp_external_bucket_name: str
+    # ES: True when institution has genai_id; False for edvise_id schools.
+    is_genai_institution: bool = True
 
     @field_validator("config_file_name", "features_table_name", "email", mode="before")
     @classmethod
@@ -703,6 +705,7 @@ class DatabricksControl(BaseModel):
                     "gcp_bucket_name": req.gcp_external_bucket_name,
                     "datakind_notification_email": req.email,
                     "DK_CC_EMAIL": req.email,
+                    "is_genai_institution": "true" if req.is_genai_institution else "false",
                 },
             )
             LOGGER.info(

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -656,6 +656,7 @@ def trigger_inference_run(
             features_table_name=req.features_table_name or "",
             gcp_external_bucket_name=get_external_bucket_name(inst_id),
             email=current_user.email or "",
+            is_genai_institution=bool(genai_id),
         )
         try:
             if is_legacy:

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -561,4 +561,51 @@ def test_trigger_es_inference_run_edvise_institution(
     assert response.json()["run_id"] == 789
     assert response.json()["m_name"] == "es_model"
     MOCK_DATABRICKS.run_es_inference.assert_called_once()
+    db_req = MOCK_DATABRICKS.run_es_inference.call_args[0][0]
+    assert db_req.is_genai_institution is False
+    MOCK_DATABRICKS.run_pdp_inference.assert_not_called()
+
+
+def test_trigger_es_inference_run_genai_institution(
+    client: TestClient, session: sqlalchemy.orm.Session
+) -> None:
+    """GenAI institutions pass is_genai_institution=True to run_es_inference."""
+    app.dependency_overrides[get_current_active_user] = lambda: DATAKINDER
+    MOCK_DATABRICKS.reset_mock()
+    genai_inst = InstTable(
+        id=uuid.uuid4(),
+        name="genai_school",
+        genai_id="genai_test_1",
+        schemas=[SchemaType.STUDENT, SchemaType.COURSE],
+        created_at=DATETIME_TESTING,
+        updated_at=DATETIME_TESTING,
+    )
+    genai_model = ModelTable(
+        id=uuid.uuid4(),
+        inst_id=genai_inst.id,
+        name="genai_es_model",
+        schema_configs=None,
+        valid=True,
+    )
+    session.add_all([genai_inst, genai_model])
+    session.commit()
+
+    MOCK_DATABRICKS.run_es_inference.return_value = DatabricksInferenceRunResponse(
+        job_run_id=790
+    )
+    MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
+        version="1", run_id="run-genai"
+    )
+
+    response = client.post(
+        "/institutions/"
+        + uuid_to_str(genai_inst.id)
+        + "/models/genai_es_model/run-inference",
+        json={"batch_name": "ignored_for_es", "config_file_name": "config.toml"},
+    )
+
+    assert response.status_code == 200
+    MOCK_DATABRICKS.run_es_inference.assert_called_once()
+    db_req = MOCK_DATABRICKS.run_es_inference.call_args[0][0]
+    assert db_req.is_genai_institution is True
     MOCK_DATABRICKS.run_pdp_inference.assert_not_called()


### PR DESCRIPTION
## Description
- It's best to have a single source of truth (SSoT) for which schools are genAI or not. This is already set up in the API so we need to feed it into the edvise/genai inference job. 
- Edvise/genAI schools also have a parameter called "use_genai_inputs" in their configs (defaults to True) and this is primarily used during onboarding, but inference remains using the SQL database parameter. In the databricks job, are also doing validation that cfg.use_genai_inputs matches is_genai_institution (built off genai_id vs. edvise_id). That's just to ensure we have everything aligned.

## Asana Task
[EDVISEBUILD-5140
](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216014005080254?focus=true)

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional