### PR TITLE
feat: using `batch_id` parameter for subfolder naming convention during GCS to DB bronze async job

### DIFF
--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -364,6 +364,8 @@ class DatabricksBronzeSyncRequest(BaseModel):
     gcp_bucket_name: str
     # Full object paths in the bucket, e.g. ["validated/file.csv"].
     validated_blob_paths: list[str]
+    # When set, bronze copies land under gcs_uploads/<batch_id>/.
+    batch_id: str | None = None
 
 
 class DatabricksBronzeSyncResponse(BaseModel):
@@ -382,7 +384,7 @@ def _build_validated_bronze_sync_job_parameters(
         "gcp_bucket_name": req.gcp_bucket_name,
         "databricks_institution_name": databricks_institution_name,
         "DB_workspace": databricks_vars["DATABRICKS_WORKSPACE"],
-        "sync_run_id": "",
+        "batch_id": (req.batch_id or "").strip(),
         "gcs_source_prefix": BRONZE_SYNC_GCS_SOURCE_PREFIX,
         "bronze_subdir": BRONZE_SYNC_BRONZE_SUBDIR,
         "max_objects": BRONZE_SYNC_MAX_OBJECTS,

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -266,6 +266,7 @@ def test_build_validated_bronze_sync_job_parameters_shape() -> None:
         inst_name="Test School",
         gcp_bucket_name="bucket-a",
         validated_blob_paths=["validated/student.csv"],
+        batch_id="abc123batch",
     )
     params = _build_validated_bronze_sync_job_parameters(req, "test_school")
     assert params["gcp_bucket_name"] == "bucket-a"
@@ -275,7 +276,7 @@ def test_build_validated_bronze_sync_job_parameters_shape() -> None:
     assert params["max_objects"] == BRONZE_SYNC_MAX_OBJECTS
     assert params["require_at_least_one_file"] == BRONZE_SYNC_REQUIRE_AT_LEAST_ONE_FILE
     assert params["strict_mode"] == BRONZE_SYNC_STRICT_MODE
-    assert params["sync_run_id"] == ""
+    assert params["batch_id"] == "abc123batch"
     assert params["include_blob_paths_json"] == '["validated/student.csv"]'
 
 

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -144,7 +144,8 @@ def _log_bronze_sync_trigger_failed(
 def _attempt_gcs_bronze_sync_trigger(
     inst_name: str,
     bucket: str,
-    validated_blob_path: str,
+    validated_blob_paths: list[str],
+    batch_id: str,
     databricks_control: DatabricksControl,
     trace_base: Dict[str, Any],
     correlation_id: str,
@@ -154,10 +155,47 @@ def _attempt_gcs_bronze_sync_trigger(
         DatabricksBronzeSyncRequest(
             inst_name=inst_name,
             gcp_bucket_name=bucket,
-            validated_blob_paths=[validated_blob_path],
+            validated_blob_paths=validated_blob_paths,
+            batch_id=batch_id,
         )
     )
-    _log_bronze_sync_success(trace_base, validated_blob_path, sync_resp.job_run_id)
+    path_for_log = (
+        validated_blob_paths[0]
+        if len(validated_blob_paths) == 1
+        else f"{len(validated_blob_paths)}_objects"
+    )
+    _log_bronze_sync_success(trace_base, path_for_log, sync_resp.job_run_id)
+
+
+def _load_batch_for_bronze_sync(
+    sess: Session, inst_id: str, batch_id: str
+) -> BatchTable:
+    """Return the batch row or raise HTTPException when batch_id is invalid."""
+    try:
+        batch = (
+            sess.execute(
+                select(BatchTable).where(
+                    and_(
+                        BatchTable.id == str_to_uuid(batch_id),
+                        BatchTable.inst_id == str_to_uuid(inst_id),
+                    )
+                )
+            )
+            .scalar_one_or_none()
+        )
+    except (ValueError, TypeError):
+        batch = None
+    if batch is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Batch not found.",
+        )
+    if batch.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Batch is set for deletion, no modifications allowed.",
+        )
+    return batch
 
 
 def _trigger_gcs_bronze_sync_if_applicable(
@@ -170,14 +208,20 @@ def _trigger_gcs_bronze_sync_if_applicable(
     bucket: str,
     databricks_control: DatabricksControl,
     correlation_id: str,
+    batch_id: Optional[str],
 ) -> None:
     """Trigger Databricks job to copy validated/ into bronze without waiting for the copy."""
     trace_base = _bronze_sync_trace_base(correlation_id, inst_id, bucket, file_name)
+    if batch_id is not None:
+        trace_base["batch_id"] = batch_id
     _log_validation_trace_json("gcs_bronze_sync_background_start", **trace_base)
 
     skip_reason = _gcs_bronze_sync_skip_reason(edvise_id, legacy_id, genai_id)
     if skip_reason is not None:
         _log_bronze_sync_skipped(trace_base, skip_reason)
+        return
+    if batch_id is None:
+        _log_bronze_sync_skipped(trace_base, "no_batch_id")
         return
 
     validated_blob_path = f"validated/{file_name}"
@@ -185,13 +229,56 @@ def _trigger_gcs_bronze_sync_if_applicable(
         _attempt_gcs_bronze_sync_trigger(
             inst_name,
             bucket,
-            validated_blob_path,
+            [validated_blob_path],
+            batch_id,
             databricks_control,
             trace_base,
             correlation_id,
         )
     except Exception:
         _log_bronze_sync_trigger_failed(trace_base, validated_blob_path, correlation_id)
+
+
+def _trigger_batch_bronze_sync_if_applicable(
+    inst: InstTable,
+    inst_id: str,
+    batch_id: str,
+    file_names: list[str],
+    databricks_control: DatabricksControl,
+) -> None:
+    """After batch creation, copy validated batch files into bronze under batch_id."""
+    skip_reason = _gcs_bronze_sync_skip_reason(
+        inst.edvise_id, inst.legacy_id, inst.genai_id
+    )
+    if skip_reason is not None or not file_names:
+        return
+
+    correlation_id = str(uuid.uuid4())
+    bucket = get_external_bucket_name(inst_id)
+    trace_base: Dict[str, Any] = {
+        "correlation_id": correlation_id,
+        "inst_id": inst_id,
+        "bucket": bucket,
+        "batch_id": batch_id,
+        "trigger_source": "batch_create",
+    }
+    _log_validation_trace_json("gcs_bronze_sync_background_start", **trace_base)
+
+    validated_blob_paths = [f"validated/{name}" for name in file_names]
+    try:
+        _attempt_gcs_bronze_sync_trigger(
+            inst.name,
+            bucket,
+            validated_blob_paths,
+            batch_id,
+            databricks_control,
+            trace_base,
+            correlation_id,
+        )
+    except Exception:
+        _log_bronze_sync_trigger_failed(
+            trace_base, validated_blob_paths[0], correlation_id
+        )
 
 
 # Cache for EDA data - TTL of 10 minutes (600 seconds)
@@ -870,6 +957,7 @@ def create_batch(
     req: BatchCreationRequest,
     current_user: Annotated[BaseUser, Depends(get_current_active_user)],
     sql_session: Annotated[Session, Depends(get_session)],
+    databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
 ) -> Any:
     """Create a new batch."""
     has_access_to_inst_or_err(inst_id, current_user)
@@ -887,6 +975,7 @@ def create_batch(
         )
         .all()
     )
+    created_new_batch = False
     if len(query_result) == 0:
         batch = BatchTable(
             name=req.name,
@@ -950,25 +1039,39 @@ def create_batch(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Database write of the batch created duplicate entries.",
             )
+        created_new_batch = True
     if len(query_result) > 1:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Batch with this name already exists.",
         )
+    batch_row = query_result[0][0]
+    batch_id_str = uuid_to_str(batch_row.id)
+    inst = (
+        local_session.get()
+        .execute(select(InstTable).where(InstTable.id == str_to_uuid(inst_id)))
+        .scalar_one_or_none()
+    )
+    if inst is not None and created_new_batch:
+        _trigger_batch_bronze_sync_if_applicable(
+            inst,
+            inst_id,
+            batch_id_str,
+            [f.name for f in batch_row.files],
+            databricks_control,
+        )
     return {
-        "batch_id": uuid_to_str(query_result[0][0].id),
-        "inst_id": uuid_to_str(query_result[0][0].inst_id),
-        "name": query_result[0][0].name,
-        "file_names_to_ids": {
-            x.name: uuid_to_str(x.id) for x in query_result[0][0].files
-        },
-        "created_by": uuid_to_str(query_result[0][0].created_by),
+        "batch_id": batch_id_str,
+        "inst_id": uuid_to_str(batch_row.inst_id),
+        "name": batch_row.name,
+        "file_names_to_ids": {x.name: uuid_to_str(x.id) for x in batch_row.files},
+        "created_by": uuid_to_str(batch_row.created_by),
         "deleted": False,
         "completed": False,
         "deletion_request_time": None,
-        "created_at": query_result[0][0].created_at,
-        "updated_by": uuid_to_str(query_result[0][0].updated_by),
-        "updated_at": query_result[0][0].updated_at,
+        "created_at": batch_row.created_at,
+        "updated_by": uuid_to_str(batch_row.updated_by),
+        "updated_at": batch_row.updated_at,
     }
 
 
@@ -1578,6 +1681,7 @@ def validation_helper(
     storage_control: StorageControl,
     sql_session: Session,
     databricks_control: DatabricksControl,
+    batch_id: Optional[str] = None,
 ) -> Any:
     """Run file validation for an institution and upsert the file record.
 
@@ -1592,7 +1696,8 @@ def validation_helper(
         current_user: Authenticated user; must have access to inst_id.
         storage_control: StorageControl instance for GCS and validate_file.
         sql_session: DB session for institution and file record.
-        databricks_control: Starts the GCS→Databricks bronze sync after validation.
+        databricks_control: Starts the GCS→Databricks bronze sync after validation when
+            batch_id is provided (non-PDP schools only).
 
     Returns:
         Dict with name, inst_id, file_types, source, status.
@@ -1652,6 +1757,8 @@ def validation_helper(
         storage_control,
         sess,
     )
+    if batch_id is not None:
+        _load_batch_for_bronze_sync(sess, inst_id, batch_id)
     # GCS validated/ write is complete; start the Databricks run now. The API waits
     # only for run_now to return a run id, not for cluster startup or file copying.
     _trigger_gcs_bronze_sync_if_applicable(
@@ -1664,6 +1771,7 @@ def validation_helper(
         bucket,
         databricks_control,
         correlation_id,
+        batch_id,
     )
     return result
 
@@ -1678,6 +1786,7 @@ def validate_file_sftp(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
+    batch_id: Annotated[Optional[str], Query()] = None,
 ) -> Any:
     """Validate a given file pulled from SFTP. The file_name should be url encoded."""
     file_name = decode_url_piece(file_name)
@@ -1694,6 +1803,7 @@ def validate_file_sftp(
         storage_control,
         sql_session,
         databricks_control,
+        batch_id=batch_id,
     )
 
 
@@ -1707,6 +1817,7 @@ def validate_file_manual_upload(
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
     sql_session: Annotated[Session, Depends(get_session)],
     databricks_control: Annotated[DatabricksControl, Depends(DatabricksControl)],
+    batch_id: Annotated[Optional[str], Query()] = None,
 ) -> Any:
     """Validate a given file. The file_name should be url encoded."""
 
@@ -1720,6 +1831,7 @@ def validate_file_manual_upload(
         storage_control,
         sql_session,
         databricks_control,
+        batch_id=batch_id,
     )
 
 

--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -172,17 +172,14 @@ def _load_batch_for_bronze_sync(
 ) -> BatchTable:
     """Return the batch row or raise HTTPException when batch_id is invalid."""
     try:
-        batch = (
-            sess.execute(
-                select(BatchTable).where(
-                    and_(
-                        BatchTable.id == str_to_uuid(batch_id),
-                        BatchTable.inst_id == str_to_uuid(inst_id),
-                    )
+        batch = sess.execute(
+            select(BatchTable).where(
+                and_(
+                    BatchTable.id == str_to_uuid(batch_id),
+                    BatchTable.inst_id == str_to_uuid(inst_id),
                 )
             )
-            .scalar_one_or_none()
-        )
+        ).scalar_one_or_none()
     except (ValueError, TypeError):
         batch = None
     if batch is None:

--- a/src/webapp/routers/data_test.py
+++ b/src/webapp/routers/data_test.py
@@ -509,6 +509,7 @@ def test_retrieve_file_as_bytes(client: TestClient) -> Any:
 
 def test_create_batch(client: TestClient) -> None:
     """Test POST /institutions/<uuid>/batch."""
+    MOCK_DATABRICKS.reset_mock()
     response = client.post(
         "/institutions/" + uuid_to_str(UUID_INVALID) + "/batch",
         json={"name": "batch_name_foo"},
@@ -543,6 +544,11 @@ def test_create_batch(client: TestClient) -> None:
         in response.json()["file_names_to_ids"]["file_input_one"]
     )
     assert len(response.json()["file_names_to_ids"]) == 1
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
+    sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
+    assert sync_req.batch_id == response.json()["batch_id"]
+    assert sync_req.validated_blob_paths == ["validated/file_input_one"]
+    assert sync_req.inst_name == "school_1"
 
 
 def test_update_batch(client: TestClient) -> None:
@@ -1387,11 +1393,30 @@ def test_validate_file_with_edvise_schema(edvise_client: TestClient) -> None:
     assert call_kwargs.get("institution_id") == "edvise"
     assert call_kwargs.get("institution_identifier") == uuid_to_str(EDVISE_INST_UUID)
 
-    # GCS → bronze Databricks job triggered for Edvise schools
+    # Non-PDP bronze sync runs only when batch_id is provided at validation time.
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
+
+
+def test_validate_with_batch_id_triggers_bronze_sync(
+    client: TestClient,
+) -> None:
+    """Validate with batch_id copies validated files into bronze under that batch folder."""
+    MOCK_STORAGE.validate_file.return_value = ["COURSE"]
+    MOCK_DATABRICKS.reset_mock()
+
+    response = client.post(
+        "/institutions/"
+        + uuid_to_str(USER_VALID_INST_UUID)
+        + "/input/validate-upload/batch_scoped_file.csv"
+        + "?batch_id="
+        + uuid_to_str(BATCH_UUID),
+    )
+
+    assert response.status_code == 200
     MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
     sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
-    assert sync_req.validated_blob_paths == ["validated/edvise_student_file.csv"]
-    assert sync_req.inst_name == "edvise_school"
+    assert sync_req.batch_id == uuid_to_str(BATCH_UUID)
+    assert sync_req.validated_blob_paths == ["validated/batch_scoped_file.csv"]
 
 
 def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
@@ -1411,10 +1436,7 @@ def test_validate_file_with_legacy_schema(legacy_client: TestClient) -> None:
     assert response.json()["inst_id"] == uuid_to_str(LEGACY_INST_UUID)
 
     assert MOCK_STORAGE.validate_file.called
-    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
-    sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
-    assert sync_req.validated_blob_paths == ["validated/legacy_student_data.csv"]
-    assert sync_req.inst_name == "legacy_school"
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_id") == "legacy"
 
@@ -1436,10 +1458,7 @@ def test_validate_file_with_genai_schema(genai_client: TestClient) -> None:
     assert response.json()["inst_id"] == uuid_to_str(GENAI_INST_UUID)
 
     assert MOCK_STORAGE.validate_file.called
-    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
-    sync_req = MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.call_args[0][0]
-    assert sync_req.validated_blob_paths == ["validated/genai_student_data.csv"]
-    assert sync_req.inst_name == "genai_school"
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
     call_kwargs = MOCK_STORAGE.validate_file.call_args.kwargs
     assert call_kwargs.get("institution_id") == "legacy"
 
@@ -1465,7 +1484,7 @@ def test_validate_file_genai_accepts_arbitrary_filename(
     assert MOCK_STORAGE.validate_file.called
     assert MOCK_STORAGE.validate_file.call_args.args[2] == ["UNKNOWN"]
     assert MOCK_STORAGE.validate_file.call_args.kwargs.get("institution_id") == "legacy"
-    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_called_once()
+    MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.assert_not_called()
 
 
 def test_validate_upload_pdp_only_institution_skips_bronze_sync(
@@ -1504,19 +1523,21 @@ def test_validate_upload_skips_bronze_sync_when_env_disabled(
 
 
 def test_validate_upload_databricks_trigger_failure_is_non_fatal(
-    edvise_client: TestClient,
+    client: TestClient,
 ) -> None:
     """Databricks trigger errors do not fail validation after the file is validated."""
-    MOCK_STORAGE.validate_file.return_value = ["STUDENT"]
+    MOCK_STORAGE.validate_file.return_value = ["COURSE"]
     MOCK_DATABRICKS.reset_mock()
     MOCK_DATABRICKS.run_validated_gcs_to_bronze_sync.side_effect = RuntimeError(
         "network failed"
     )
     try:
-        response = edvise_client.post(
+        response = client.post(
             "/institutions/"
-            + uuid_to_str(EDVISE_INST_UUID)
-            + "/input/validate-upload/edvise_student_file.csv",
+            + uuid_to_str(USER_VALID_INST_UUID)
+            + "/input/validate-upload/edvise_student_file.csv"
+            + "?batch_id="
+            + uuid_to_str(BATCH_UUID),
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
## Description
We need batch-scoped bronze folders in order to be able to know where these files are from / which uploads. This also feeds in well with our legacy, edvise/genai jobs since they'll also be fed in a batch_id. 

## Asana Task
[EDVISEBUILD-5139
](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216014005080242?focus=true)

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [ ]  No special deployment steps required

### Rollback Plan

Describe or check:

- [ ]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional