### PR TITLE
feat(api): mirror accepted_terms and invite_validated on AccountTable (#261 follow-up)

### DIFF
--- a/src/webapp/database.py
+++ b/src/webapp/database.py
@@ -395,6 +395,12 @@ class AccountTable(Base):
     access_type: Mapped[str | None] = mapped_column(
         String(VAR_CHAR_LENGTH), nullable=True
     )
+    accepted_terms: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    invite_validated: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
     # profile_photo_path : Mapped[dict[str, str]] = mapped_column(String(VAR_CHAR_LENGTH), nullable=True)
     created_at = mapped_column(
         DateTime(timezone=True),


### PR DESCRIPTION
## Summary

Lands the change from #261 on `develop`. That PR was merged into `feat/db-ownership-pr3-runinfo` instead of `develop`, so the AccountTable ORM fields never reached the main integration branch.

This is a clean cherry-pick of `a852be2` onto current `develop` (single file, 6 lines).

## Context

Stack order was #258 → #259 → #260 → #261. #258–#260 are already on `develop`; only #261 was missing.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216015476753546?focus=true

## Test plan

- [x] CI passes
- [x] No DDL change (columns already exist in Laravel-owned `users` table per `docs/DB_SCHEMA_CONTRACT.md`)


Made with [Cursor](https://cursor.com)