### PR TITLE
fix(api): coerce Databricks model version to str for RunInfo responses

### DIFF
--- a/src/webapp/routers/data.py
+++ b/src/webapp/routers/data.py
@@ -1907,6 +1907,11 @@ def add_custom_school_job(
             inst_name=inst_result[0][0].name,
             model_name=model_name,
         )
+        model_version = (
+            str(latest_model_version.version)
+            if latest_model_version.version is not None
+            else None
+        )
 
         job = JobTable(
             id=job_run_id,
@@ -1917,7 +1922,7 @@ def add_custom_school_job(
             model_id=query_result[0][0].id,
             output_valid=True,
             completed=True,
-            model_version=latest_model_version.version,
+            model_version=model_version,
             model_run_id=latest_model_version.run_id,
         )
         local_session.get().add(job)
@@ -1927,7 +1932,7 @@ def add_custom_school_job(
             "m_name": model_name,
             "run_id": job_run_id,
             "output_filename": f"{job_run_id}/inference_output.csv",
-            "model_version": latest_model_version.version,
+            "model_version": model_version,
             "model_run_id": latest_model_version.run_id,
             "created_by": current_user.user_id,
             "triggered_at": triggered_timestamp,

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -219,6 +219,13 @@ class ModelInfo(BaseModel):
     deleted: bool | None = None
 
 
+def _model_version_as_str(version: Any) -> str | None:
+    """Databricks model versions are ints; RunInfo and job rows store them as str."""
+    if version is None:
+        return None
+    return str(version)
+
+
 class RunInfo(BaseModel):
     """The RunInfo object that's returned."""
 
@@ -740,6 +747,8 @@ def trigger_inference_run(
             inst_name=inst_result[0][0].name,
             model_name=model_name,
         )
+        model_version = _model_version_as_str(latest_model_version.version)
+        model_run_id = latest_model_version.run_id
         job = JobTable(
             id=res.job_run_id,
             triggered_at=triggered_timestamp,
@@ -747,8 +756,8 @@ def trigger_inference_run(
             batch_name=req.batch_name,
             model_id=shared_model_result[0][0].id,
             output_valid=False,
-            model_version=latest_model_version.version,
-            model_run_id=latest_model_version.run_id,
+            model_version=model_version,
+            model_run_id=model_run_id,
         )
         local_session.get().add(job)
         return {
@@ -759,8 +768,8 @@ def trigger_inference_run(
             "triggered_at": triggered_timestamp,
             "batch_name": req.batch_name,
             "output_valid": False,
-            "model_version": latest_model_version.version,
-            "model_run_id": latest_model_version.run_id,
+            "model_version": model_version,
+            "model_run_id": model_run_id,
         }
 
     # PDP inference (existing logic)
@@ -846,6 +855,8 @@ def trigger_inference_run(
         inst_name=inst_result[0][0].name,
         model_name=model_name,
     )
+    model_version = _model_version_as_str(latest_model_version.version)
+    model_run_id = latest_model_version.run_id
     job = JobTable(
         id=res.job_run_id,
         triggered_at=triggered_timestamp,
@@ -853,8 +864,8 @@ def trigger_inference_run(
         batch_name=req.batch_name,
         model_id=query_result[0][0].id,
         output_valid=False,
-        model_version=latest_model_version.version,
-        model_run_id=latest_model_version.run_id,
+        model_version=model_version,
+        model_run_id=model_run_id,
     )
     local_session.get().add(job)
     return {
@@ -865,8 +876,8 @@ def trigger_inference_run(
         "triggered_at": triggered_timestamp,
         "batch_name": req.batch_name,
         "output_valid": False,
-        "model_version": latest_model_version.version,
-        "model_run_id": latest_model_version.run_id,
+        "model_version": model_version,
+        "model_run_id": model_run_id,
     }
 
 

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -366,7 +366,7 @@ def test_trigger_inference_run(client: TestClient) -> None:
         job_run_id=123
     )
     MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
-        version="1", run_id="run-inference"
+        version=1, run_id="run-inference"
     )
     response = client.post(
         "/institutions/"
@@ -532,7 +532,7 @@ def test_trigger_inference_run_derives_schema_configs_when_null(
         job_run_id=456
     )
     MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
-        version="1", run_id="run-abc"
+        version=1, run_id="run-abc"
     )
 
     response = client.post(
@@ -668,7 +668,7 @@ def test_trigger_es_inference_run_edvise_institution(
         job_run_id=789
     )
     MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
-        version="2", run_id="run-es"
+        version=2, run_id="run-es"
     )
 
     response = client.post(
@@ -761,7 +761,7 @@ def test_trigger_es_inference_run_genai_institution(
         job_run_id=790
     )
     MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
-        version="1", run_id="run-genai"
+        version=1, run_id="run-genai"
     )
 
     response = client.post(
@@ -847,7 +847,7 @@ def test_trigger_es_inference_run_genai_unknown_only_schemas(
         job_run_id=791
     )
     MOCK_DATABRICKS.fetch_model_version.return_value = mock.Mock(
-        version="1", run_id="run-genai-unknown"
+        version=1, run_id="run-genai-unknown"
     )
 
     response = client.post(


### PR DESCRIPTION
## Summary
- Fixes `ResponseValidationError` on `POST .../run-inference` introduced by #260
- Databricks `ModelVersionInfo.version` is an `int`, but `RunInfo.model_version` is typed as `str`
- Coerces version to string before persisting to `JobTable` and returning the API response (PDP, ES, Legacy, GenAI)
- Updates inference tests to mock integer versions so this regression is caught

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216055232235290?focus=true

## Test plan
- [x] `uv run pytest src/webapp/routers/models_test.py` — 15 passed
- [ ] Trigger inference on dev for a PDP school and confirm 200 response with `model_version` as a string
- [ ] Trigger inference on dev for an ES/GenAI school and confirm same


Made with [Cursor](https://cursor.com)