### PR TITLE
feat(api): add delete model run endpoint

### DIFF
--- a/src/webapp/database.py
+++ b/src/webapp/database.py
@@ -104,6 +104,46 @@ def _setup_test_institutions(session: Session) -> None:
                             )  # type: ignore
                         )
                     session.merge(batch_table)
+                model_ids_by_name: dict[str, uuid.UUID] = {}
+                for model in inst.get("models", []):
+                    model_id = uuid.UUID(model["m_id"])
+                    model_ids_by_name[model["name"]] = model_id
+                    session.merge(
+                        ModelTable(
+                            id=model_id,
+                            inst_id=uuid.UUID(inst["inst_id"]),
+                            name=model["name"],
+                            created_by=LOCAL_USER_UUID,
+                            valid=model.get("valid", True),
+                            created_at=DATETIME_TESTING,
+                            updated_at=DATETIME_TESTING,
+                        )
+                    )
+                for run in inst.get("runs", []):
+                    model_name = run.get("model_name") or run.get("m_name")
+                    if not model_name or model_name not in model_ids_by_name:
+                        raise ValueError(
+                            f"Run {run.get('run_id')}: model_name must match a models[].name entry"
+                        )
+                    triggered_at = run.get("triggered_at")
+                    if isinstance(triggered_at, str):
+                        triggered_at = datetime.datetime.fromisoformat(triggered_at)
+                    if triggered_at is None:
+                        triggered_at = DATETIME_TESTING
+                    session.merge(
+                        JobTable(
+                            id=run["run_id"],
+                            model_id=model_ids_by_name[model_name],
+                            created_by=LOCAL_USER_UUID,
+                            triggered_at=triggered_at,
+                            batch_name=run["batch_name"],
+                            output_filename=run.get("output_filename"),
+                            output_valid=run.get("output_valid", False),
+                            completed=run.get("completed", False),
+                            model_run_id=run.get("model_run_id"),
+                            model_version=run.get("model_version"),
+                        )
+                    )
 
 
 @event.listens_for(Mapper, "before_insert")

--- a/src/webapp/gcsdbutils.py
+++ b/src/webapp/gcsdbutils.py
@@ -4,6 +4,7 @@ Helper functions that use storage and session.
 
 from sqlalchemy import and_, update
 from sqlalchemy.future import select
+from sqlalchemy.orm import Session
 
 from .utilities import (
     str_to_uuid,
@@ -15,6 +16,7 @@ from .database import (
     FileTable,
     JobTable,
 )
+from .gcsutil import StorageControl
 
 
 def get_job_id(filename: str) -> int:
@@ -43,14 +45,16 @@ def is_file_approved(filename: str) -> bool:
     raise ValueError("Unexpected filename structure.")
 
 
-def update_db_from_bucket(inst_id: str, session, storage_control):
+def update_db_from_bucket(
+    inst_id: str, session: Session, storage_control: StorageControl
+) -> None:
     """Updates the sql tables by checking if there are new files in the bucket.
 
     Note that while all output files will be added to the file table, potentially with their own approval status, the JobTable will only refer to the csv inference output and indicate validity (approval) value for that file.
     This means that for a single run it's possible to have some output files be approved and some be unapproved but that is confusing and we discourage it.
     Note that deleted files are handled upon file retrieval, not here."""
     dir_prefix = ["approved/", "unapproved/"]
-    all_files = []
+    all_files: list[str] = []
     for d in dir_prefix:
         all_files = all_files + storage_control.list_blobs_in_folder(
             get_external_bucket_name(inst_id), d

--- a/src/webapp/gcsdbutils.py
+++ b/src/webapp/gcsdbutils.py
@@ -23,7 +23,7 @@ def get_job_id(filename: str) -> int:
     return int(tmp.split("/")[0])
 
 
-def get_filename_without_approve_dir(filename: str) -> int:
+def get_filename_without_approve_dir(filename: str) -> str:
     """Remove the approved or unapproved prefix as that isn't a property of the filename itself
     and may change if the file gets approved or unapproved."""
     if filename.startswith("approved/"):

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -31,13 +31,14 @@ from ..database import (
     get_session,
     local_session,
     BatchTable,
+    FileTable,
     InstTable,
     ModelTable,
     JobTable,
 )
 import traceback
 import logging
-from ..gcsdbutils import update_db_from_bucket
+from ..gcsdbutils import get_filename_without_approve_dir, update_db_from_bucket
 from ..config import env_vars
 
 from ..gcsutil import StorageControl
@@ -596,6 +597,100 @@ def read_inst_model_output(
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Run not found.",
     )
+
+
+@router.delete("/{inst_id}/models/{model_name}/run/{run_id}")
+def delete_model_run(
+    inst_id: str,
+    model_name: str,
+    run_id: int,
+    current_user: Annotated[BaseUser, Depends(get_current_active_user)],
+    sql_session: Annotated[Session, Depends(get_session)],
+    storage_control: Annotated[StorageControl, Depends(StorageControl)],
+) -> Any:
+    """Deletes a given execution of a given model.
+
+    Only visible to users of that institution or Datakinder access types.
+    """
+    model_name = decode_url_piece(model_name)
+    has_access_to_inst_or_err(inst_id, current_user)
+    local_session.set(sql_session)
+    sess = local_session.get()
+    query_result = (
+        sess.execute(
+            select(ModelTable).where(
+                and_(
+                    ModelTable.name == model_name,
+                    ModelTable.inst_id == str_to_uuid(inst_id),
+                )
+            )
+        )
+        .all()
+    )
+    if len(query_result) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Model not found.",
+        )
+    if len(query_result) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Multiple models of the same name found, this should not have happened.",
+        )
+    job = next(
+        (elem for elem in (query_result[0][0].jobs or []) if elem.id == run_id),
+        None,
+    )
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Run not found.",
+        )
+
+    bucket = get_external_bucket_name(inst_id)
+    output_names: set[str] = set()
+    for dir_prefix in ("approved/", "unapproved/"):
+        for blob_path in storage_control.list_blobs_in_folder(
+            bucket, f"{dir_prefix}{run_id}/"
+        ):
+            try:
+                storage_control.delete_file(bucket_name=bucket, file_name=blob_path)
+                output_names.add(get_filename_without_approve_dir(blob_path))
+            except ValueError:
+                pass
+
+    if output_names:
+        file_rows = (
+            sess.execute(
+                select(FileTable).where(
+                    and_(
+                        FileTable.inst_id == str_to_uuid(inst_id),
+                        FileTable.name.in_(output_names),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for file_row in file_rows:
+            sess.delete(file_row)
+
+    try:
+        sess.delete(job)
+        sess.commit()
+    except Exception as e:
+        sess.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"DB run delete failed: {e}",
+        ) from e
+
+    return {
+        "inst_id": inst_id,
+        "model_name": model_name,
+        "run_id": run_id,
+        "status": "Run deleted",
+    }
 
 
 def convert_files_to_dict(files):

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -616,17 +616,14 @@ def delete_model_run(
     has_access_to_inst_or_err(inst_id, current_user)
     local_session.set(sql_session)
     sess = local_session.get()
-    query_result = (
-        sess.execute(
-            select(ModelTable).where(
-                and_(
-                    ModelTable.name == model_name,
-                    ModelTable.inst_id == str_to_uuid(inst_id),
-                )
+    query_result = sess.execute(
+        select(ModelTable).where(
+            and_(
+                ModelTable.name == model_name,
+                ModelTable.inst_id == str_to_uuid(inst_id),
             )
         )
-        .all()
-    )
+    ).all()
     if len(query_result) == 0:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -599,16 +599,19 @@ def read_inst_model_output(
     )
 
 
-@router.delete("/{inst_id}/models/{model_name}/run/{run_id}")
+@router.delete("/{inst_id}/models/{model_name}/run/{job_run_id}")
 def delete_model_run(
     inst_id: str,
     model_name: str,
-    run_id: int,
+    job_run_id: int,
     current_user: Annotated[BaseUser, Depends(get_current_active_user)],
     sql_session: Annotated[Session, Depends(get_session)],
     storage_control: Annotated[StorageControl, Depends(StorageControl)],
 ) -> Any:
-    """Deletes a given execution of a given model.
+    """Deletes a given inference job run for a model.
+
+    ``job_run_id`` is the Databricks Jobs run id (also ``job.id``), not the
+    MLflow ``model_run_id``.
 
     Only visible to users of that institution or Datakinder access types.
     """
@@ -635,7 +638,7 @@ def delete_model_run(
             detail="Multiple models of the same name found, this should not have happened.",
         )
     job = next(
-        (elem for elem in (query_result[0][0].jobs or []) if elem.id == run_id),
+        (elem for elem in (query_result[0][0].jobs or []) if elem.id == job_run_id),
         None,
     )
     if job is None:
@@ -648,7 +651,7 @@ def delete_model_run(
     output_names: set[str] = set()
     for dir_prefix in ("approved/", "unapproved/"):
         for blob_path in storage_control.list_blobs_in_folder(
-            bucket, f"{dir_prefix}{run_id}/"
+            bucket, f"{dir_prefix}{job_run_id}/"
         ):
             try:
                 storage_control.delete_file(bucket_name=bucket, file_name=blob_path)
@@ -685,7 +688,7 @@ def delete_model_run(
     return {
         "inst_id": inst_id,
         "model_name": model_name,
-        "run_id": run_id,
+        "run_id": job_run_id,
         "status": "Run deleted",
     }
 

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -340,7 +340,7 @@ def test_read_inst_model_output(client: TestClient) -> None:
 
 
 def test_delete_model_run(client: TestClient, session: sqlalchemy.orm.Session) -> None:
-    """Test DELETE /institutions/{inst_id}/models/{model_name}/run/{run_id}."""
+    """Test DELETE /institutions/{inst_id}/models/{model_name}/run/{job_run_id}."""
     MOCK_STORAGE.list_blobs_in_folder.return_value = []
     url = (
         "/institutions/"

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -339,6 +339,44 @@ def test_read_inst_model_output(client: TestClient) -> None:
     assert same_run_info_orderless(response_model, expected_model)
 
 
+def test_delete_model_run(client: TestClient, session: sqlalchemy.orm.Session) -> None:
+    """Test DELETE /institutions/{inst_id}/models/{model_name}/run/{run_id}."""
+    MOCK_STORAGE.list_blobs_in_folder.return_value = []
+    url = (
+        "/institutions/"
+        + uuid_to_str(USER_VALID_INST_UUID)
+        + "/models/sample_model_for_school_1/run/"
+        + str(RUN_ID)
+    )
+
+    response = client.delete(url)
+    assert response.status_code == 200
+    assert response.json() == {
+        "inst_id": uuid_to_str(USER_VALID_INST_UUID),
+        "model_name": "sample_model_for_school_1",
+        "run_id": RUN_ID,
+        "status": "Run deleted",
+    }
+    assert session.get(JobTable, RUN_ID) is None
+
+    MOCK_STORAGE.list_blobs_in_folder.return_value = []
+    get_response = client.get(url)
+    assert get_response.status_code == 404
+    assert get_response.json() == {"detail": "Run not found."}
+
+
+def test_delete_model_run_not_found(client: TestClient) -> None:
+    """Deleting a missing run returns 404."""
+    MOCK_STORAGE.list_blobs_in_folder.return_value = []
+    response = client.delete(
+        "/institutions/"
+        + uuid_to_str(USER_VALID_INST_UUID)
+        + "/models/sample_model_for_school_1/run/999"
+    )
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Run not found."}
+
+
 def test_create_model(client: TestClient) -> None:
     """Depending on timeline, fellows may not get to this."""
     schema_config_1 = {


### PR DESCRIPTION
## Description

- Add `DELETE /institutions/{inst_id}/models/{model_name}/run/{run_id}` to remove a completed model run
- Extend local dev institution seeding to load optional `models` and `runs` from `local_inst_data.json`

## Asana Task
[EDVISEBUILD-5001 - Add delete option to "model run history" page for DataKinders](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1213031796227679?focus=true)

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional