### PR TITLE
fix(validation): skip upload-time Pandera validation for ES

### DIFF
--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -1,8 +1,9 @@
 """File validation functions for upload workflows.
 
-PDP and Edvise uploads validate through Pandera schemas imported from the
-``edvise`` package. Legacy uploads keep the API's any-format CSV read plus PII
-guard. The old API-local JSON schema validation path has been removed.
+PDP uploads validate through Pandera schemas imported from the ``edvise``
+package. Edvise Schema (ES) and Legacy uploads use any-format CSV read plus a
+PII column-name guard (no Pandera at upload time; ES schema checks run later in
+Databricks). The old API-local JSON schema validation path has been removed.
 """
 
 from __future__ import annotations
@@ -411,7 +412,11 @@ def _validate_edvise_with_repo_schema(
     model_list: List[str],
     institution_id: str,
 ) -> Dict[str, Any]:
-    """Validate Edvise Schema uploads with upstream raw Edvise Pandera schemas."""
+    """Validate Edvise Schema uploads with upstream raw Edvise Pandera schemas.
+
+    Not used by the live upload router today (ES skips Pandera at upload time).
+    Kept for unit tests and a possible future restore of upload-time schema checks.
+    """
     schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
     if schema_class is None:
         raise HardValidationError(
@@ -529,16 +534,17 @@ def _validate_pdp_with_edvise_read(
 # --------------------------------------------------------------------------- #
 
 
-def _validate_legacy_any_format(
+def _validate_any_format_csv(
     filename: Src,
     enc: str,
     models: Union[str, List[str], None],
 ) -> Dict[str, Any]:
     """
-    Legacy institutions: accept any CSV format (encoding check only, no schema).
+    Accept any CSV format (encoding/parse + PII column-name guard; no Pandera).
 
-    Reads the file as CSV with no column or type checks; returns the DataFrame
-    as-is as normalized_df so it can be written to validated/.
+    Used for Legacy and Edvise Schema (ES) uploads. Reads the file as CSV with no
+    column or type checks; returns the DataFrame as-is as normalized_df so it can
+    be written to validated/. ES Pandera checks still run later in Databricks.
 
     Args:
         filename: Path or file-like object for the CSV.
@@ -573,15 +579,15 @@ def _validate_legacy_any_format(
             UnicodeDecodeError,
             OSError,
         ) as e:
-            logger.exception("Legacy CSV read failed: %s", e)
+            logger.exception("Any-format CSV read failed: %s", e)
             raise HardValidationError(
-                schema_errors="Legacy upload: could not read CSV.",
+                schema_errors="Upload: could not read CSV.",
                 failure_cases=[str(e)],
             ) from e
     if df is None or not isinstance(df, pd.DataFrame):
         df = pd.DataFrame()
 
-    # PII check: reject legacy uploads that contain columns indicating PII (before moving to raw/validated).
+    # PII check: reject uploads with columns indicating PII (before raw/validated).
     # Run whenever there are columns (including header-only CSVs: df.empty is True for 0 rows).
     if len(df.columns) > 0:
         # Lazy import to avoid circular dependency: validation_error_formatter imports from this module.
@@ -589,13 +595,12 @@ def _validate_legacy_any_format(
 
         pii_columns = [str(c) for c in df.columns if _is_pii_column(str(c))]
         if pii_columns:
-            logger.warning(
-                "Legacy upload rejected: PII columns detected: %s", pii_columns
-            )
+            logger.warning("Upload rejected: PII columns detected: %s", pii_columns)
             raise HardValidationError(
                 schema_errors=(
-                    "Legacy upload: file contains columns that may contain personally identifiable information (PII). "
-                    "Please remove or de-identify these columns before uploading."
+                    "Upload: file contains columns that may contain personally "
+                    "identifiable information (PII). Please remove or de-identify "
+                    "these columns before uploading."
                 ),
                 failure_cases=pii_columns,
             )
@@ -609,6 +614,10 @@ def _validate_legacy_any_format(
     }
 
 
+# Back-compat alias for callers/tests that still use the legacy name.
+_validate_legacy_any_format = _validate_any_format_csv
+
+
 def validate_dataset(
     filename: Src,
     models: Union[str, List[str], None] = None,
@@ -620,15 +629,16 @@ def validate_dataset(
     """
     Validate a dataset using the active institution upload workflow.
 
-    Detects encoding, then routes to legacy any-format handling or PDP/Edvise
+    Detects encoding, then routes to any-format handling for Legacy/ES, or PDP
     repo Pandera validation for supported single-model STUDENT/COURSE uploads.
-    Other PDP/Edvise model sets are rejected explicitly; the API-local JSON
-    schema validation fallback has been removed.
+    Other PDP model sets are rejected explicitly; the API-local JSON schema
+    validation fallback has been removed.
 
     Args:
         filename: CSV path or file-like object.
         models: Model name(s) to validate.
-        institution_id: Validation namespace, or ``"legacy"`` for any-format validation.
+        institution_id: Validation namespace (``"pdp"``, ``"edvise"``, or ``"legacy"``).
+            ``"edvise"`` and ``"legacy"`` skip Pandera at upload time.
         institution_identifier: Optional UUID string for caller context (e.g. Edvise).
         pdp_cohort_converter_func: Optional cohort transform before Pandera; default ``None``.
             Batch PDP jobs may still apply school-specific cohort converters via ``dataio``.
@@ -648,18 +658,13 @@ def validate_dataset(
         raise HardValidationError(schema_errors="decode_error", failure_cases=[str(ex)])
     _reset_to_start_if_possible(filename)
 
-    if institution_id == "legacy":
-        return _validate_legacy_any_format(filename, enc, models)
+    # ES and Legacy: parse CSV + PII guard only. ES Pandera runs in Databricks
+    # (optionally after school converters from bronze training_inputs/dataio.py).
+    if institution_id in ("legacy", "edvise"):
+        return _validate_any_format_csv(filename, enc, models)
 
     model_list = _model_list_from_models(models)
     schema_class = pdp_edvise.get_edvise_schema_for_upload(institution_id, model_list)
-    if schema_class is not None and institution_id == "edvise":
-        return _validate_edvise_with_repo_schema(
-            filename,
-            enc,
-            model_list,
-            institution_id,
-        )
     if schema_class is not None:
         return _validate_pdp_with_edvise_read(
             filename,

--- a/src/webapp/validation_pdp_edvise.py
+++ b/src/webapp/validation_pdp_edvise.py
@@ -1,9 +1,9 @@
 """Pandera schemas re-exported from edvise for upload validation.
 
-Imports raw PDP and Edvise schema classes so uploads use the same column and type
-rules as edvise pipeline audits. Cohort row transforms run in ``validation.py``
-(optional converter) and can differ from batch ``dataio`` hooks; this module only
-supplies schema classes and helpers.
+Imports raw PDP and Edvise schema classes. PDP uploads use these at upload time.
+ES uploads currently skip Pandera (any-format CSV + PII guard); cohort/course
+converters and schema checks run later in Databricks. This module supplies
+schema classes and helpers when callers need them.
 
 Requires the ``edvise`` package (see pyproject.toml).
 """
@@ -34,7 +34,9 @@ def _get_hard_validation_error_class() -> type:
     return HardValidationError
 
 
-# Institution namespaces that use edvise repo schemas for single-model uploads.
+# Institution namespaces with edvise repo schema classes available.
+# Upload-time Pandera currently runs for "pdp" only; "edvise" skips Pandera at
+# upload (any-format CSV) and validates later in Databricks.
 PDP_EDVISE_NAMESPACES = frozenset({"pdp", "edvise"})
 
 
@@ -84,9 +86,10 @@ def get_edvise_schema_for_upload(
     """
     Return the edvise repo schema class for this upload, or None.
 
-    Use this as the single check: when not None, run that schema. PDP and
-    Edvise single-model STUDENT/COURSE uploads use repo validation (edvise
-    package required).
+    Use this as the single check: when not None, a repo schema class exists.
+    PDP single-model STUDENT/COURSE uploads use these at upload time. Edvise
+    schema classes remain available for helpers/tests, but ES upload validation
+    currently skips Pandera.
 
     Args:
         institution_id: Schema namespace (e.g. "pdp", "edvise", or "legacy").

--- a/src/webapp/validation_pdp_read_path_test.py
+++ b/src/webapp/validation_pdp_read_path_test.py
@@ -92,47 +92,15 @@ def test_validate_file_reader_pdp_course_calls_edvise_read_path(tmp_path: Path) 
         assert mock_pdp.call_args[0][2] == ["COURSE"]
 
 
-def test_validate_file_reader_edvise_student_calls_repo_schema_path(
+def test_validate_file_reader_edvise_student_skips_pandera(
     tmp_path: Path,
 ) -> None:
-    """When institution_id is edvise and allowed_schema is [STUDENT], Edvise repo schema path is used."""
-    csv_path = tmp_path / "edvise_student.csv"
-    pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
-
-    with (
-        patch(
-            "src.webapp.validation._validate_edvise_with_repo_schema",
-            return_value={
-                "validation_status": "passed",
-                "schemas": ["STUDENT"],
-                "missing_optional": [],
-                "unknown_extra_columns": [],
-                "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
-            },
-        ) as mock_edvise_schema,
-    ):
-        result = validate_file_reader(
-            str(csv_path),
-            ["STUDENT"],
-            institution_id="edvise",
-        )
-        assert result["validation_status"] == "passed"
-        assert result["schemas"] == ["STUDENT"]
-        mock_edvise_schema.assert_called_once()
-        call_args = mock_edvise_schema.call_args[0]
-        assert call_args[2] == ["STUDENT"]
-        assert call_args[3] == "edvise"
-
-
-def test_validate_file_reader_edvise_routes_before_schema_merge(
-    tmp_path: Path,
-) -> None:
-    """Edvise repo validation should not depend on populated JSON schema docs."""
+    """When institution_id is edvise, uploads use any-format CSV (no Pandera)."""
     csv_path = tmp_path / "edvise_student.csv"
     pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
 
     with patch(
-        "src.webapp.validation._validate_edvise_with_repo_schema",
+        "src.webapp.validation._validate_any_format_csv",
         return_value={
             "validation_status": "passed",
             "schemas": ["STUDENT"],
@@ -140,6 +108,27 @@ def test_validate_file_reader_edvise_routes_before_schema_merge(
             "unknown_extra_columns": [],
             "normalized_df": pd.DataFrame({"learner_id": ["s1"]}),
         },
+    ) as mock_any_format:
+        result = validate_file_reader(
+            str(csv_path),
+            ["STUDENT"],
+            institution_id="edvise",
+        )
+        assert result["validation_status"] == "passed"
+        assert result["schemas"] == ["STUDENT"]
+        mock_any_format.assert_called_once()
+        assert mock_any_format.call_args[0][2] == ["STUDENT"]
+
+
+def test_validate_file_reader_edvise_does_not_call_repo_schema_path(
+    tmp_path: Path,
+) -> None:
+    """ES upload validation must not invoke repo Pandera schema validation."""
+    csv_path = tmp_path / "edvise_student.csv"
+    pd.DataFrame({"learner_id": ["s1"]}).to_csv(csv_path, index=False)
+
+    with patch(
+        "src.webapp.validation._validate_edvise_with_repo_schema",
     ) as mock_edvise_schema:
         result = validate_file_reader(
             str(csv_path),
@@ -148,7 +137,7 @@ def test_validate_file_reader_edvise_routes_before_schema_merge(
         )
 
     assert result["validation_status"] == "passed"
-    mock_edvise_schema.assert_called_once()
+    mock_edvise_schema.assert_not_called()
 
 
 def test_validate_edvise_with_repo_schema_preserves_string_values(

--- a/src/webapp/validation_test.py
+++ b/src/webapp/validation_test.py
@@ -206,20 +206,18 @@ def test_validate_file_reader_pdp_student_routes_to_repo_validation(
     assert mock_validate.call_args.args[3] == "pdp"
 
 
-def test_validate_file_reader_edvise_course_routes_to_repo_validation(
+def test_validate_file_reader_edvise_course_skips_pandera(
     tmp_csv_file: str,
 ) -> None:
-    """Edvise COURSE uploads use repo-backed validation, not JSON schema docs."""
-    expected_df = pd.DataFrame({"course_id": ["c1"]})
-
+    """Edvise COURSE uploads skip Pandera and use any-format CSV validation."""
     with patch(
-        "src.webapp.validation._validate_edvise_with_repo_schema",
+        "src.webapp.validation._validate_any_format_csv",
         return_value={
             "validation_status": "passed",
             "schemas": ["COURSE"],
             "missing_optional": [],
             "unknown_extra_columns": [],
-            "normalized_df": expected_df,
+            "normalized_df": pd.DataFrame({"course_id": ["c1"]}),
         },
     ) as mock_validate:
         result = validate_file_reader(
@@ -229,10 +227,8 @@ def test_validate_file_reader_edvise_course_routes_to_repo_validation(
         )
 
     assert result["validation_status"] == "passed"
-    assert result["normalized_df"] is expected_df
     mock_validate.assert_called_once()
     assert mock_validate.call_args.args[2] == ["COURSE"]
-    assert mock_validate.call_args.args[3] == "edvise"
 
 
 def test_validate_file_reader_pdp_rejects_unsupported_model_set(
@@ -250,16 +246,35 @@ def test_validate_file_reader_pdp_rejects_unsupported_model_set(
     assert "SEMESTER" in str(exc_info.value)
 
 
-def test_validate_file_reader_edvise_rejects_multi_model_upload(
-    tmp_csv_file: str,
+def test_validate_file_reader_edvise_accepts_schema_invalid_csv(
+    tmp_path: Path,
 ) -> None:
-    """Edvise multi-model uploads are rejected instead of using old JSON validation."""
+    """ES uploads pass without Pandera so school converters can run later in Databricks."""
+    csv_path = tmp_path / "messy_student.csv"
+    csv_path.write_text("weird_col,another\nx,y\n", encoding="utf-8")
+
+    result = validate_file_reader(
+        str(csv_path),
+        ["STUDENT"],
+        institution_id="edvise",
+    )
+
+    assert result["validation_status"] == "passed"
+    assert result["schemas"] == ["STUDENT"]
+    assert list(result["normalized_df"].columns) == ["weird_col", "another"]
+
+
+def test_validate_file_reader_edvise_rejects_pii_columns(tmp_path: Path) -> None:
+    """ES any-format path still rejects PII-looking column names."""
+    csv_path = tmp_path / "with_pii.csv"
+    csv_path.write_text("learner_id,email\n1,a@b.com\n", encoding="utf-8")
+
     with pytest.raises(HardValidationError) as exc_info:
         validate_file_reader(
-            tmp_csv_file,
-            ["STUDENT", "COURSE"],
+            str(csv_path),
+            ["STUDENT"],
             institution_id="edvise",
         )
 
-    assert "edvise repo" in str(exc_info.value)
-    assert "STUDENT, COURSE" in str(exc_info.value)
+    assert "PII" in (exc_info.value.schema_errors or "")
+    assert "email" in (exc_info.value.failure_cases or [])


### PR DESCRIPTION
## Summary
- route ES uploads through the any-format CSV path instead of upload-time Pandera
- retain CSV parsing and PII column-name protections
- leave school-specific conversion and schema validation to the Databricks ES pipeline

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216606862971306?focus=true

## Test plan
- [x] Run `src/webapp/validation_test.py`
- [x] Run `src/webapp/validation_pdp_read_path_test.py`
- [x] Run `src/webapp/validation_pdp_edvise_test.py`
- [x] Verify Black formatting on changed Python files

Made with [Cursor](https://cursor.com)