### PR TITLE
feat: add archived field to /models endpoint API

### DIFF
--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -218,6 +218,7 @@ class ModelInfo(BaseModel):
     created_by: str | None = None
     valid: bool = True
     deleted: bool | None = None
+    archived: bool = False
 
 
 def _model_version_as_str(version: Any) -> str | None:
@@ -297,6 +298,7 @@ def read_inst_models(
                 "created_by": uuid_to_str(elem[0].created_by),
                 "deleted": elem[0].deleted,
                 "valid": elem[0].valid,
+                "archived": bool(elem[0].archived),
             }
         )
     return res
@@ -373,6 +375,7 @@ def create_model(
         "created_by": uuid_to_str(query_result[0][0].created_by),
         "deleted": query_result[0][0].deleted,
         "valid": query_result[0][0].valid,
+        "archived": bool(query_result[0][0].archived),
     }
 
 
@@ -420,6 +423,7 @@ def read_inst_model(
         "created_by": uuid_to_str(query_result[0][0].created_by),
         "deleted": query_result[0][0].deleted,
         "valid": query_result[0][0].valid,
+        "archived": bool(query_result[0][0].archived),
     }
 
 

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -63,6 +63,7 @@ def same_model_orderless(a_elem: ModelInfo, b_elem: ModelInfo) -> bool:
         or a_elem.m_id != b_elem.m_id
         or a_elem.valid != b_elem.valid
         or a_elem.deleted != b_elem.deleted
+        or a_elem.archived != b_elem.archived
     ):
         return False
     return True
@@ -247,6 +248,7 @@ def test_read_inst_models(client: TestClient) -> None:
             inst_id="1d7c75c33eda42949c6675ea8af97b55",
             deleted=None,
             valid=True,
+            archived=False,
         ),
     )
 
@@ -279,6 +281,7 @@ def test_read_inst_model(client: TestClient) -> None:
         m_id="e4862c62829440d8ab4c9c298f02f619",
         name="sample_model_for_school_1",
         valid=True,
+        archived=False,
     )
     assert same_model_orderless(response_model, expected_model)
 
@@ -300,6 +303,21 @@ def test_archive_model(client: TestClient, session: sqlalchemy.orm.Session) -> N
     assert model_row is not None
     assert model_row.archived == 1
     assert client.patch(base + "sample_model_for_school_1/archive").status_code == 409
+
+    # Confirm the archived state is reflected on the model read endpoints.
+    get_response = client.get(base + "sample_model_for_school_1")
+    assert get_response.status_code == 200
+    assert get_response.json()["archived"] is True
+
+    list_response = client.get(
+        "/institutions/" + uuid_to_str(USER_VALID_INST_UUID) + "/models"
+    )
+    assert list_response.status_code == 200
+    assert next(
+        m["archived"]
+        for m in list_response.json()
+        if m["name"] == "sample_model_for_school_1"
+    )
 
 
 def test_read_inst_model_outputs(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Add `archived` to the `ModelInfo` response model.
- Populate `archived` (cast from the existing `ModelTable.archived` int column) on `GET /{inst_id}/models`, `GET /{inst_id}/models/{model_name}`, and `POST /{inst_id}/models/`, so callers no longer have to rely solely on the `PATCH /{inst_id}/models/{model_name}/archive` response to know a model's archived state.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216766104607108?focus=true

## Test plan
- [x] `uv run pytest src/webapp/routers/models_test.py -q` (18 passed)
- [x] `uv run ruff check` / `uv run mypy` on changed files
- [x] Added assertions confirming `archived` is reflected on the list/detail endpoints after archiving a model in `test_archive_model`

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216726403243105