### PR TITLE
feat: add archived attribute to /models endpoints

### DIFF
--- a/src/webapp/database.py
+++ b/src/webapp/database.py
@@ -115,6 +115,7 @@ def _setup_test_institutions(session: Session) -> None:
                             name=model["name"],
                             created_by=LOCAL_USER_UUID,
                             valid=model.get("valid", True),
+                            archived=model.get("archived", 0),
                             created_at=DATETIME_TESTING,
                             updated_at=DATETIME_TESTING,
                         )

--- a/src/webapp/routers/models.py
+++ b/src/webapp/routers/models.py
@@ -218,6 +218,7 @@ class ModelInfo(BaseModel):
     created_by: str | None = None
     valid: bool = True
     deleted: bool | None = None
+    archived: int = 0
 
 
 def _model_version_as_str(version: Any) -> str | None:
@@ -297,6 +298,7 @@ def read_inst_models(
                 "created_by": uuid_to_str(elem[0].created_by),
                 "deleted": elem[0].deleted,
                 "valid": elem[0].valid,
+                "archived": elem[0].archived,
             }
         )
     return res
@@ -373,6 +375,7 @@ def create_model(
         "created_by": uuid_to_str(query_result[0][0].created_by),
         "deleted": query_result[0][0].deleted,
         "valid": query_result[0][0].valid,
+        "archived": query_result[0][0].archived,
     }
 
 
@@ -420,6 +423,7 @@ def read_inst_model(
         "created_by": uuid_to_str(query_result[0][0].created_by),
         "deleted": query_result[0][0].deleted,
         "valid": query_result[0][0].valid,
+        "archived": query_result[0][0].archived,
     }
 
 

--- a/src/webapp/routers/models_test.py
+++ b/src/webapp/routers/models_test.py
@@ -63,6 +63,7 @@ def same_model_orderless(a_elem: ModelInfo, b_elem: ModelInfo) -> bool:
         or a_elem.m_id != b_elem.m_id
         or a_elem.valid != b_elem.valid
         or a_elem.deleted != b_elem.deleted
+        or a_elem.archived != b_elem.archived
     ):
         return False
     return True
@@ -247,6 +248,7 @@ def test_read_inst_models(client: TestClient) -> None:
             inst_id="1d7c75c33eda42949c6675ea8af97b55",
             deleted=None,
             valid=True,
+            archived=0,
         ),
     )
 
@@ -279,6 +281,7 @@ def test_read_inst_model(client: TestClient) -> None:
         m_id="e4862c62829440d8ab4c9c298f02f619",
         name="sample_model_for_school_1",
         valid=True,
+        archived=0,
     )
     assert same_model_orderless(response_model, expected_model)
 


### PR DESCRIPTION
## Description
Add the archived field to /models endpoints.

## Asana Task
[EDVISEBUILD-5638 - Add archived field to /models endpoint API](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216766104607108?focus=true)

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional