### PR TITLE
ci: bump stale edvise major/minor pin on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,11 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
 
-  # Release branches: flag if a newer edvise major/minor release is available upstream
+  # Release branches: auto-bump the edvise pin if a newer major/minor release is available upstream
   edvise-version-check:
     if: startsWith(github.head_ref, 'release/')
+    permissions:
+      contents: write
     uses: ./.github/workflows/edvise-version-check.yml
 
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
 
+  # Release branches: flag if a newer edvise major/minor release is available upstream
+  edvise-version-check:
+    if: startsWith(github.head_ref, 'release/')
+    uses: ./.github/workflows/edvise-version-check.yml
+
   ci:
     needs:
       [
@@ -47,6 +52,7 @@ jobs:
         pre-release,
         style,
         tests,
+        edvise-version-check,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -60,6 +66,7 @@ jobs:
             "${{ needs.enforce-targets.result }}" \
             "${{ needs.pre-release.result }}" \
             "${{ needs.style.result }}" \
-            "${{ needs.tests.result }}"; do
+            "${{ needs.tests.result }}" \
+            "${{ needs.edvise-version-check.result }}"; do
             case "$result" in success|skipped) ;; *) exit 1 ;; esac
           done

--- a/.github/workflows/edvise-version-check.yml
+++ b/.github/workflows/edvise-version-check.yml
@@ -4,13 +4,20 @@ on:
   workflow_call:
 
 jobs:
-  check-edvise-version:
+  bump-edvise-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
-      - name: Compare locked edvise version against latest upstream release
+      - name: Set up Python environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Bump locked edvise version if a newer major/minor release is available upstream
         run: |
           set -euo pipefail
 
@@ -37,9 +44,33 @@ jobs:
           latest_major=$(echo "$latest" | cut -d. -f1)
           latest_minor=$(echo "$latest" | cut -d. -f2)
 
-          if [ "$latest_major" -gt "$current_major" ] || { [ "$latest_major" -eq "$current_major" ] && [ "$latest_minor" -gt "$current_minor" ]; }; then
-            echo "::error::This release is pinned to edvise v$current, but a newer major/minor release (v$latest) is available upstream. Bump the 'edvise' dependency constraint in pyproject.toml and the matching [tool.uv.sources] tag, run 'uv lock', and commit the update before finishing this release (patch-only lag is fine)."
+          if [ "$latest_major" -lt "$current_major" ] || { [ "$latest_major" -eq "$current_major" ] && [ "$latest_minor" -le "$current_minor" ]; }; then
+            echo "edvise dependency is up to date at the major/minor level. Nothing to bump."
+            exit 0
+          fi
+
+          echo "::notice::Bumping edvise from v$current to v$latest (newer major/minor release available upstream)."
+
+          new_constraint="${latest_major}.${latest_minor}.0"
+
+          sed -i -E "s/edvise~=[0-9]+\.[0-9]+\.[0-9]+/edvise~=${new_constraint}/" pyproject.toml
+          sed -i -E "s#(edvise = \{ git = \"https://github.com/datakind/edvise.git\", tag = \")v[0-9]+\.[0-9]+\.[0-9]+(\" \})#\1v${latest}\2#" pyproject.toml
+
+          if ! grep -q "edvise~=${new_constraint}" pyproject.toml; then
+            echo "::error::Failed to update the 'edvise' dependency constraint in pyproject.toml"
+            exit 1
+          fi
+          if ! grep -q "tag = \"v${latest}\"" pyproject.toml; then
+            echo "::error::Failed to update the [tool.uv.sources] edvise tag in pyproject.toml"
             exit 1
           fi
 
-          echo "edvise dependency is up to date at the major/minor level."
+          uv lock
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump edvise to ~=${new_constraint} (v${latest})"
+          git push origin "HEAD:${{ github.head_ref }}"
+
+          echo "::notice::Pushed a commit bumping edvise to ~=${new_constraint} (tag v${latest}) onto ${{ github.head_ref }}."

--- a/.github/workflows/edvise-version-check.yml
+++ b/.github/workflows/edvise-version-check.yml
@@ -1,0 +1,45 @@
+name: edvise-version-check
+
+on:
+  workflow_call:
+
+jobs:
+  check-edvise-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Compare locked edvise version against latest upstream release
+        run: |
+          set -euo pipefail
+
+          current=$(grep -A1 -m1 '^name = "edvise"$' uv.lock | grep '^version' | sed -E 's/version = "(.*)"/\1/')
+          if [ -z "$current" ]; then
+            echo "::error::Could not determine the locked edvise version from uv.lock"
+            exit 1
+          fi
+
+          latest=$(git ls-remote --tags --refs https://github.com/datakind/edvise.git \
+            | sed -E 's#.*refs/tags/v##' \
+            | sort -V \
+            | tail -n1)
+          if [ -z "$latest" ]; then
+            echo "::error::Could not determine the latest edvise release tag"
+            exit 1
+          fi
+
+          echo "Locked edvise version:  $current"
+          echo "Latest edvise release:  v$latest"
+
+          current_major=$(echo "$current" | cut -d. -f1)
+          current_minor=$(echo "$current" | cut -d. -f2)
+          latest_major=$(echo "$latest" | cut -d. -f1)
+          latest_minor=$(echo "$latest" | cut -d. -f2)
+
+          if [ "$latest_major" -gt "$current_major" ] || { [ "$latest_major" -eq "$current_major" ] && [ "$latest_minor" -gt "$current_minor" ]; }; then
+            echo "::error::This release is pinned to edvise v$current, but a newer major/minor release (v$latest) is available upstream. Bump the 'edvise' dependency constraint in pyproject.toml and the matching [tool.uv.sources] tag, run 'uv lock', and commit the update before finishing this release (patch-only lag is fine)."
+            exit 1
+          fi
+
+          echo "edvise dependency is up to date at the major/minor level."


### PR DESCRIPTION
## Summary
- Adds a new `edvise-version-check` job that compares the `edvise` version locked in `uv.lock` against the latest tag on `datakind/edvise`. If a newer major/minor release is available upstream (patch lag is fine), it auto-bumps: updates the `edvise` dependency constraint and `[tool.uv.sources]` tag in `pyproject.toml` to the latest release, regenerates `uv.lock`, and pushes the commit straight back onto the release branch.
- Wires it into the `ci` workflow as a `workflow_call` reusable job, gated with `if: startsWith(github.head_ref, 'release/')` so it only runs on PRs whose source branch is a release branch (mirroring how `pre-release` is gated on `base_ref == 'main'`). Grants `contents: write` so it can push the bump commit.
- The pushed commit retriggers `ci` via the PR's `synchronize` event; the re-run finds `edvise` already up to date and passes cleanly.
- Manual patch-level pins (e.g. pinning to a specific hotfix tag within the same major/minor) are left alone, since the job only acts when major/minor drifts.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216966527824478?focus=true

## Test plan
- [ ] Confirm the job is skipped (not failed) on a non-`release/*` branch PR.
- [ ] Confirm the job no-ops on a `release/*` PR when `edvise` in `uv.lock` is already at the latest major/minor.
- [ ] Confirm the job pushes a commit bumping `pyproject.toml`/`uv.lock` on a `release/*` PR when `uv.lock` is pinned to an older major/minor `edvise` version, and that the resulting re-run passes.

Made with [Cursor](https://cursor.com)