### PR TITLE
fix: send correct notification parameter names to PDP inference launcher

### DIFF
--- a/src/webapp/databricks.py
+++ b/src/webapp/databricks.py
@@ -774,7 +774,8 @@ class DatabricksControl(BaseModel):
                     ],  # is this value the same PER environ? dev/staging/prod
                     "gcp_bucket_name": req.gcp_external_bucket_name,
                     "model_name": req.model_name,
-                    "notification_email": req.email,
+                    "datakind_notification_email": req.email,
+                    "DK_CC_EMAIL": req.email,
                 },
             )
             LOGGER.info(

--- a/src/webapp/databricks_test.py
+++ b/src/webapp/databricks_test.py
@@ -14,12 +14,14 @@ from .databricks import (
     DATABRICKS_VALIDATED_BRONZE_SYNC_JOB_ID_ENV,
     DatabricksBronzeSyncRequest,
     DatabricksControl,
+    DatabricksPDPInferenceRunRequest,
     DatabricksSharedInferenceRunRequest,
     _build_shared_inference_job_parameters,
     _build_validated_bronze_sync_job_parameters,
     _resolve_pipeline_job,
     _resolve_validated_bronze_sync_job_id,
 )
+from .utilities import SchemaType
 
 
 @pytest.fixture
@@ -398,3 +400,50 @@ def test_run_validated_gcs_to_bronze_sync_calls_run_now_with_bundle_params(
     params = run_kwargs["job_parameters"]
     assert params["include_blob_paths_json"] == '["validated/foo.csv"]'
     assert params["gcs_source_prefix"] == BRONZE_SYNC_GCS_SOURCE_PREFIX
+
+
+def test_run_pdp_inference_sends_datakind_notification_email_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_pdp_inference must send the archived job's real parameter names.
+
+    Regression test: this previously sent a stale ``notification_email`` key
+    that doesn't match any declared job parameter, so the value was silently
+    dropped and the launcher failed with a missing DK_CC_EMAIL error.
+    """
+    import src.webapp.databricks as db_mod
+
+    monkeypatch.setitem(
+        db_mod.databricks_vars, "DATABRICKS_HOST_URL", "https://example.databricks.com"
+    )
+    monkeypatch.setitem(db_mod.databricks_vars, "DATABRICKS_WORKSPACE", "dev_sst_02")
+    monkeypatch.setitem(db_mod.gcs_vars, "GCP_SERVICE_ACCOUNT_EMAIL", "sa@example.com")
+
+    workspace = mock.Mock()
+    job = SimpleNamespace(job_id=123)
+    workspace.jobs.list.return_value = iter([job])
+    run_response = mock.Mock()
+    run_response.response.run_id = 9002
+    workspace.jobs.run_now.return_value = run_response
+
+    with mock.patch.object(db_mod, "WorkspaceClient", return_value=workspace):
+        ctrl = DatabricksControl()
+        req = DatabricksPDPInferenceRunRequest(
+            inst_name="My Inst",
+            filepath_to_type={
+                "student.csv": [SchemaType.STUDENT],
+                "course.csv": [SchemaType.COURSE],
+            },
+            model_name="retention_model",
+            email="user@example.com",
+            gcp_external_bucket_name="my-bucket",
+        )
+        resp = ctrl.run_pdp_inference(req)
+
+    assert resp.job_run_id == 9002
+    workspace.jobs.run_now.assert_called_once()
+    _run_args, run_kwargs = workspace.jobs.run_now.call_args
+    params = run_kwargs["job_parameters"]
+    assert params["datakind_notification_email"] == "user@example.com"
+    assert params["DK_CC_EMAIL"] == "user@example.com"
+    assert "notification_email" not in params


### PR DESCRIPTION
## Summary
- `run_pdp_inference()` was calling `w.jobs.run_now(job_id, job_parameters={..., "notification_email": req.email})`. Databricks job parameters are matched by **exact declared name** on the job — `edvise_versioned_inference_launcher` only declares `datakind_notification_email` and `DK_CC_EMAIL`, so `notification_email` was silently dropped every time this ran.
- Downstream, the launcher's archived-bundle parameter-contract validation (see [datakind/edvise#251](https://github.com/datakind/edvise/pull/251) for the related fix on that side) then failed closed with `Parameter contract validation failed: ... missing required parameter value(s): 'DK_CC_EMAIL'`, blocking PDP inference runs triggered through the webapp.
- `run_es_inference()` / `run_legacy_inference()` already do this correctly via `_build_shared_inference_job_parameters()`, which is the pattern this PR brings `run_pdp_inference()` in line with.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216920327381761?focus=true

## Fix
Send `datakind_notification_email` and `DK_CC_EMAIL` (both set to `req.email`) instead of the stale `notification_email` key.

## Test plan
- [x] Added `test_run_pdp_inference_sends_datakind_notification_email_params`, a regression test asserting the correct keys are sent to `run_now` and the stale `notification_email` key is absent.
- [x] `uv run python -m pytest` — 404 passed
- [x] `uv tool run ruff check src/webapp/databricks.py src/webapp/databricks_test.py` — clean
- [x] `uv tool run ruff format --check src/webapp/databricks.py src/webapp/databricks_test.py` — clean

Made with [Cursor](https://cursor.com)