### PR TITLE
fix: revert accidental release/1.4.0 merge into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 1.4.0 (2026-07-27)
-- feat: update PDP Inference pipeline name for versioned inference pipeline 
-
 ## 1.3.0 (2026-07-22)
 - feat: validate ES uploads with bronze `dataio` converters and Pandera (#273)
 - feat: apply bronze `config.toml` `grade_map` before ES course Pandera (#273)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "src"
-version = "1.4.0"
+version = "1.3.0"
 description = "School-agnostic lib for implementing Edvise workflows."
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -30,7 +30,7 @@ dependencies = [
     "mlflow~=2.22",
     "cachetools",
     "types-cachetools",
-    "edvise~=1.7.0",
+    "edvise~=1.5.0",
 ]
 
 [project.urls]
@@ -59,7 +59,7 @@ allow-direct-references = true
 default-groups = ["dev"]
 
 [tool.uv.sources]
-edvise = { git = "https://github.com/datakind/edvise.git", tag = "v1.7.0" }
+edvise = { git = "https://github.com/datakind/edvise.git", tag = "v1.5.0" }
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform != 'win32'",
@@ -695,8 +695,8 @@ wheels = [
 
 [[package]]
 name = "edvise"
-version = "1.7.0"
-source = { git = "https://github.com/datakind/edvise.git?tag=v1.7.0#5fec14060c310114c97583e9045843e24cb06f0c" }
+version = "1.5.0"
+source = { git = "https://github.com/datakind/edvise.git?tag=v1.5.0#0f359a51c22e689cc21f42bfcf7279e71d2c41fb" }
 dependencies = [
     { name = "databricks-connect" },
     { name = "databricks-sdk" },
@@ -3128,7 +3128,7 @@ wheels = [
 
 [[package]]
 name = "src"
-version = "1.4.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -3178,7 +3178,7 @@ requires-dist = [
     { name = "cloud-sql-python-connector", extras = ["pymysql"], specifier = "~=1.14.0" },
     { name = "databricks-sdk", specifier = "~=0.38.0" },
     { name = "databricks-sql-connector", extras = ["pyarrow"], specifier = "~=4.2.0" },
-    { name = "edvise", git = "https://github.com/datakind/edvise.git?tag=v1.7.0" },
+    { name = "edvise", git = "https://github.com/datakind/edvise.git?tag=v1.5.0" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.4" },
     { name = "google-cloud-storage", specifier = "==2.19.0" },
     { name = "jsonpickle", specifier = "~=4.0.1" },


### PR DESCRIPTION
## Description
PR #279 (\`release/1.4.0\` → \`develop\`) merged the 1.4.0 release-prep commits (\`chore: release 1.4.0\`, \`chore(release): bump edvise to 1.7.0\`) directly into \`develop\` instead of \`main\`. This was accidental — release branches should merge to \`main\` first (which tags the release and triggers \`post-release.yml\`), then get synced back into \`develop\`.

This PR reverts that merge commit (\`0628628\`, `-m 1`) to restore \`develop\` to its pre-merge state (version \`1.3.0\`, \`edvise~=1.5.0\`). No other content is affected — the diff is limited to \`CHANGELOG.md\`, \`pyproject.toml\`, and \`uv.lock\`.

The actual 1.4.0 release still needs to be completed properly via \`release/1.4.0\` → \`main\` in a follow-up.

## Asana
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1216960497083260?focus=true

## Deployment Notes
No special deployment steps required.

## Rollback Plan
Standard revert is sufficient (\`git revert\`).

Made with [Cursor](https://cursor.com)