### PR TITLE
perf(validation): read PDP course CSV once before datetime format retries

### DIFF
--- a/src/webapp/validation.py
+++ b/src/webapp/validation.py
@@ -43,6 +43,7 @@ from edvise.data_audit.raw_course_grade_map import (
     resolve_es_grade_map,
 )
 from edvise.dataio.read import (
+    from_csv_file,
     read_raw_es_cohort_data,
     read_raw_es_course_data,
     read_raw_pdp_cohort_data,
@@ -639,13 +640,15 @@ def _read_pdp_course_edvise(
     converters = (
         (course_converter_func,) if course_converter_func is not None else ()
     ) + default_converters
+    raw_df = from_csv_file(path)
+    schema = pdp_edvise.get_edvise_schema_for_models(["COURSE"])
     last_error: Optional[Exception] = None
     for converter in converters:
         for fmt in PDP_COURSE_DTTM_FORMATS:
             try:
                 return read_raw_pdp_course_data(
-                    file_path=path,
-                    schema=pdp_edvise.get_edvise_schema_for_models(["COURSE"]),
+                    df=raw_df,
+                    schema=schema,
                     dttm_format=fmt,
                     converter_func=converter,
                     spark_session=None,

--- a/src/webapp/validation_pdp_read_path_test.py
+++ b/src/webapp/validation_pdp_read_path_test.py
@@ -420,21 +420,38 @@ def test_validate_pdp_with_edvise_read_non_callable_course_converter_raises_hard
 def test_read_pdp_course_edvise_success_returns_dataframe() -> None:
     """When read_raw_pdp_course_data returns a df, _read_pdp_course_edvise returns it."""
     expected = pd.DataFrame({"course_id": ["c1"], "credits": [3]})
-    with patch(
-        "src.webapp.validation.read_raw_pdp_course_data",
-        return_value=expected,
+    with (
+        patch(
+            "src.webapp.validation.from_csv_file",
+            return_value=pd.DataFrame({"x": [1]}),
+        ),
+        patch(
+            "src.webapp.validation.read_raw_pdp_course_data",
+            return_value=expected,
+        ) as mock_read,
     ):
         result = _read_pdp_course_edvise("/nonexistent/path.csv")
     pd.testing.assert_frame_equal(result, expected)
+    assert mock_read.call_count == 1
+    assert mock_read.call_args.kwargs.get("df") is not None
+    assert "file_path" not in mock_read.call_args.kwargs or mock_read.call_args.kwargs.get(
+        "file_path"
+    ) is None
 
 
 def test_read_pdp_course_edvise_all_attempts_fail_raises_hard_validation_error() -> (
     None
 ):
     """When all converter/format attempts raise ValueError, HardValidationError is raised."""
-    with patch(
-        "src.webapp.validation.read_raw_pdp_course_data",
-        side_effect=ValueError("bad datetime"),
+    with (
+        patch(
+            "src.webapp.validation.from_csv_file",
+            return_value=pd.DataFrame({"x": [1]}),
+        ),
+        patch(
+            "src.webapp.validation.read_raw_pdp_course_data",
+            side_effect=ValueError("bad datetime"),
+        ),
     ):
         with pytest.raises(HardValidationError, match="datetime format") as exc_info:
             _read_pdp_course_edvise("/nonexistent/path.csv")
@@ -447,15 +464,21 @@ def test_read_pdp_course_edvise_all_attempts_fail_raises_hard_validation_error()
 def test_read_pdp_course_edvise_falls_back_after_custom_converter_fails() -> None:
     """When custom converter fails all datetime formats, default PDP converter is used."""
     expected = pd.DataFrame({"course_id": ["c1"]})
-    with patch(
-        "src.webapp.validation.read_raw_pdp_course_data",
-        side_effect=[
-            ValueError("bad datetime"),
-            ValueError("bad datetime"),
-            ValueError("bad datetime"),
-            expected,
-        ],
-    ) as mock_read:
+    with (
+        patch(
+            "src.webapp.validation.from_csv_file",
+            return_value=pd.DataFrame({"x": [1]}),
+        ),
+        patch(
+            "src.webapp.validation.read_raw_pdp_course_data",
+            side_effect=[
+                ValueError("bad datetime"),
+                ValueError("bad datetime"),
+                ValueError("bad datetime"),
+                expected,
+            ],
+        ) as mock_read,
+    ):
         result = _read_pdp_course_edvise(
             "/path.csv",
             course_converter_func=lambda df: df,  # noqa: ARG005
@@ -468,10 +491,16 @@ def test_read_pdp_course_edvise_custom_converter_tried_first() -> None:
     """When course_converter_func is provided, it is tried before default converters."""
     expected = pd.DataFrame({"course_id": ["c1"]})
     custom_converter = lambda df: df  # noqa: E731
-    with patch(
-        "src.webapp.validation.read_raw_pdp_course_data",
-        return_value=expected,
-    ) as mock_read:
+    with (
+        patch(
+            "src.webapp.validation.from_csv_file",
+            return_value=pd.DataFrame({"x": [1]}),
+        ),
+        patch(
+            "src.webapp.validation.read_raw_pdp_course_data",
+            return_value=expected,
+        ) as mock_read,
+    ):
         result = _read_pdp_course_edvise(
             "/path.csv", course_converter_func=custom_converter
         )


### PR DESCRIPTION
## Summary
- Read the PDP course CSV once in `_read_pdp_course_edvise`, then retry datetime formats/converters with `df=` instead of re-reading from disk.
- Update unit tests to mock `from_csv_file` and assert the `df=` path.

Depends on the edvise change that adds optional `df` to `read_raw_pdp_course_data` (feature/validation-timeout).

## Test plan
- [ ] `pytest src/webapp/validation_pdp_read_path_test.py` passes
- [ ] Large COURSE upload validates without repeating full CSV loads (one `loaded rows` log line)
- [ ] Confirm edvise `df=` support is released/pinned before merging to environments that use published edvise


Made with [Cursor](https://cursor.com)