### PR TITLE
feat(ci): enable Alembic api-migrate on webapp Cloud Build

### DIFF
--- a/cloudbuild-webapp.yaml
+++ b/cloudbuild-webapp.yaml
@@ -1,8 +1,10 @@
 # Cloud Build config for webapp. Reused by per-environment triggers (dev, qa, staging, prod).
 # Each trigger sets _REGION, _ENVIRONMENT, and _SERVICE (Cloud Run service name).
-# Alembic: runs ${_ENVIRONMENT}-api-migrate before deploy unless _SKIP_API_MIGRATE=true.
-# Default skip=true so QA/unstamped envs are safe; set false on stamped env triggers only
-# (e.g. edvise-api-web-dev after alembic stamp). See docs/ALEMBIC_CUTOVER.md.
+# Alembic: runs ${_ENVIRONMENT}-api-migrate before deploy only when _SKIP_API_MIGRATE=false.
+# Default skip is anything other than "false" so QA/unstamped envs are safe. Set
+# _SKIP_API_MIGRATE=false only on stamped env triggers (e.g. edvise-api-web-dev after
+# alembic stamp), and only when that trigger's _ENVIRONMENT matches the intended DB/job
+# (QA must not reuse _ENVIRONMENT=dev while skip is false). See docs/ALEMBIC_CUTOVER.md.
 substitutions:
   _REGION: us-east4
   _SERVICE: edvise-api
@@ -10,6 +12,7 @@ substitutions:
   _SKIP_API_MIGRATE: "true"
 steps:
   - name: ghcr.io/astral-sh/uv:debian
+    id: upgrade-edvise-lock
     entrypoint: bash
     args:
       - -c
@@ -18,6 +21,8 @@ steps:
         apt-get update && apt-get install -y --no-install-recommends git
         uv lock --upgrade-package edvise
   - name: gcr.io/cloud-builders/docker
+    id: build-webapp
+    waitFor: ["upgrade-edvise-lock"]
     args:
       - build
       - "-f"
@@ -28,22 +33,28 @@ steps:
       - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:latest"
       - .
   - name: gcr.io/cloud-builders/docker
+    id: push-webapp-sha
+    waitFor: ["build-webapp"]
     args:
       - push
       - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:$COMMIT_SHA"
   - name: gcr.io/cloud-builders/docker
+    id: push-webapp-latest
+    waitFor: ["build-webapp"]
     args:
       - push
       - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:latest"
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
     id: RUN api-migrate job
+    waitFor: ["push-webapp-sha"]
     entrypoint: bash
     args:
       - -c
       - |
         set -e
-        if [ "${_SKIP_API_MIGRATE}" = "true" ]; then
-          echo "Skipping api-migrate (_SKIP_API_MIGRATE=true)"
+        # Fail-closed toward skip: only run migrate when explicitly "false".
+        if [ "${_SKIP_API_MIGRATE}" != "false" ]; then
+          echo "Skipping api-migrate (_SKIP_API_MIGRATE=${_SKIP_API_MIGRATE})"
           exit 0
         fi
         IMAGE="${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:$COMMIT_SHA"
@@ -52,12 +63,16 @@ steps:
         # Prefer update+execute so a missing job fails closed (deploy would create a
         # minimal job whose CMD is FastAPI, not alembic).
         gcloud run jobs update "$${JOB}" \
+          --project="${PROJECT_ID}" \
           --image="$${IMAGE}" \
           --region="${_REGION}"
         gcloud run jobs execute "$${JOB}" \
+          --project="${PROJECT_ID}" \
           --region="${_REGION}" \
           --wait
   - name: gcr.io/cloud-builders/gcloud
+    id: deploy-webapp
+    waitFor: ["RUN api-migrate job"]
     args:
       - run
       - deploy
@@ -67,6 +82,8 @@ steps:
       - "--region"
       - "${_REGION}"
   - name: curlimages/curl
+    id: notify-slack
+    waitFor: ["deploy-webapp"]
     args:
       - "-X"
       - POST
@@ -78,7 +95,6 @@ steps:
         {"text":"🚀 $TRIGGER_NAME → *$REPO_NAME* deployed · `$BRANCH_NAME`"}
       - >-
         https://hooks.slack.com/triggers/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
-    id: notify-slack
 timeout: 600s
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild-webapp.yaml
+++ b/cloudbuild-webapp.yaml
@@ -1,8 +1,13 @@
 # Cloud Build config for webapp. Reused by per-environment triggers (dev, qa, staging, prod).
-# Each trigger sets _REGION and _ENVIRONMENT; deploys Cloud Run service "${_ENVIRONMENT}-webapp".
+# Each trigger sets _REGION, _ENVIRONMENT, and _SERVICE (Cloud Run service name).
+# Alembic: runs ${_ENVIRONMENT}-api-migrate before deploy unless _SKIP_API_MIGRATE=true.
+# Default skip=true so QA/unstamped envs are safe; set false on stamped env triggers only
+# (e.g. edvise-api-web-dev after alembic stamp). See docs/ALEMBIC_CUTOVER.md.
 substitutions:
   _REGION: us-east4
   _SERVICE: edvise-api
+  _ENVIRONMENT: dev
+  _SKIP_API_MIGRATE: "true"
 steps:
   - name: ghcr.io/astral-sh/uv:debian
     entrypoint: bash
@@ -30,6 +35,28 @@ steps:
     args:
       - push
       - "${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:latest"
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    id: RUN api-migrate job
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        if [ "${_SKIP_API_MIGRATE}" = "true" ]; then
+          echo "Skipping api-migrate (_SKIP_API_MIGRATE=true)"
+          exit 0
+        fi
+        IMAGE="${_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/webapp:$COMMIT_SHA"
+        JOB="${_ENVIRONMENT}-api-migrate"
+        echo "Updating and executing Cloud Run job $${JOB} with $${IMAGE}"
+        # Prefer update+execute so a missing job fails closed (deploy would create a
+        # minimal job whose CMD is FastAPI, not alembic).
+        gcloud run jobs update "$${JOB}" \
+          --image="$${IMAGE}" \
+          --region="${_REGION}"
+        gcloud run jobs execute "$${JOB}" \
+          --region="${_REGION}" \
+          --wait
   - name: gcr.io/cloud-builders/gcloud
     args:
       - run

--- a/docs/ALEMBIC_CUTOVER.md
+++ b/docs/ALEMBIC_CUTOVER.md
@@ -11,12 +11,16 @@ See also: [DB_SCHEMA_CONTRACT.md](./DB_SCHEMA_CONTRACT.md).
 |-------|----------|
 | Alembic config | `alembic.ini`, `alembic/` |
 | Baseline revision | `alembic/versions/20260803_596894_baseline_api_tables.py` |
-| Cloud Run job | `${ENV}-api-migrate` (terraform `deployment` jobs) |
-| Cloud Build | webapp trigger runs api-migrate unless `_SKIP_API_MIGRATE=true` |
-| Skip flag | per-env terraform `skip_api_migrate` (default `true`) |
+| Cloud Run job | `${ENV}-api-migrate` (create via terraform or `gcloud run jobs create`) |
+| Cloud Build (live path) | `cloudbuild-webapp.yaml` on triggers like `edvise-api-web-dev` |
+| Skip flag | `_SKIP_API_MIGRATE` substitution (default `"true"` in the YAML) |
 | `create_all` | LOCAL only (`database.py` `setup_db`) |
 
-Default: **`skip_api_migrate = true`** so auto-deploy does not run `upgrade` before stamp.
+**Important:** pushes to `develop` deploy via **`edvise-api-web-dev`** + `cloudbuild-webapp.yaml`,
+not the terraform-inline `dev-webapp` trigger. Enable auto-migrate by setting that trigger’s
+`_SKIP_API_MIGRATE=false` **after** stamp (and only once `${env}-api-migrate` exists).
+
+Default in YAML: **`_SKIP_API_MIGRATE=true`** so QA / unstamped envs skip migrate.
 
 ## Local verification (before merge)
 
@@ -103,20 +107,28 @@ Or run the automated check: `uv run pytest tests/alembic -q`
    alembic upgrade head   # expect no-op
    ```
 
-5. Verify: `SELECT * FROM alembic_version;` → `20260803_596894`
-6. Flip skip off **for this env only**: set `skip_api_migrate = false` in that
-   environment’s terraform variables / tfvars and `terraform apply`
-   (prefer this over Console-only edits — the next terraform apply would reset a Console-only change).
-7. Re-run webapp Cloud Build (or push a no-op commit); confirm migrate step succeeds
-   (`jobs update` + `execute --wait` so deploy does not proceed until migrate finishes).
+5. Verify stamp (pick one):
+   - `gcloud run jobs execute ${ENV}-api-migrate --region=${REGION} --args=current --wait`
+     and check logs for `20260803_596894`
+   - or `SELECT * FROM alembic_version;` → `20260803_596894`
+6. Enable auto-migrate on the **live** webapp trigger (Console):
+   - Trigger: `edvise-api-web-dev` (project `dev-sst-02`)
+   - Substitution: `_SKIP_API_MIGRATE` = `false`
+   - Leave other env triggers at `true` until those DBs are stamped and have
+     `${_ENVIRONMENT}-api-migrate`.
+   - Do **not** rely on a full `dev-terraform` apply to flip this; that apply can
+     reconcile large unrelated drift. Prefer Console (or a narrowly scoped change).
+7. Re-run webapp Cloud Build (or push a no-op commit); confirm the
+   `RUN api-migrate job` step updates/executes `${_ENVIRONMENT}-api-migrate` with
+   `--wait` before deploy.
 8. Smoke: login/auth + inference run.
 
 ## Staging cutover (after short dev soak)
 
 1. Cloud SQL **on-demand backup**
-2. Refresh staging `${ENV}-api-migrate` image (same as Option A above), then stamp
-3. Set **staging** `skip_api_migrate = false` via terraform + apply (dev can stay
-   `false` independently; prod stays `true` until stamped)
+2. Ensure staging `${ENV}-api-migrate` exists; refresh image, then stamp
+3. Set that staging webapp trigger’s `_SKIP_API_MIGRATE=false` (Console), leave
+   prod/other envs at `true` until stamped
 4. Manual Cloud Build for webapp
 5. Smoke auth, inference, UI pages that use run metadata
 

--- a/docs/ALEMBIC_CUTOVER.md
+++ b/docs/ALEMBIC_CUTOVER.md
@@ -59,20 +59,23 @@ Or run the automated check: `uv run pytest tests/alembic -q`
 
 ## Dev cutover (merge day)
 
-1. Merge this PR to `develop` (auto-deploy; migrate step **skipped** while
-   `skip_api_migrate=true`).
-2. Ensure terraform has applied so `${env}-api-migrate` exists.
+1. Merge Alembic + (this) Cloud Build PR to `develop`. Auto-deploy uses
+   **`edvise-api-web-dev`** + `cloudbuild-webapp.yaml`; migrate stays **skipped**
+   while `_SKIP_API_MIGRATE` is not exactly `false` (YAML default `"true"`).
+   Ignore the terraform-inline `${env}-webapp` trigger for enablement — it is
+   not the live develop deploy path.
+2. Ensure `${env}-api-migrate` exists (prefer `gcloud run jobs create` mirroring
+   webapp DB/VPC wiring, or a narrowly scoped terraform change). Avoid a full
+   blind `dev-terraform` apply — live GCP has substantial drift from the
+   checked-in modules.
    - The `${env}-terraform` Cloud Build trigger is **manual** (not push-on-develop).
-   - Run that trigger, or `terraform apply` in `terraform/environments/dev`.
 3. Export / compare **dev** DDL to the schema contract if not already done.
 4. Stamp (pick one):
 
    **Option A — Cloud Run job** (required: refresh the job image first).
 
-   Terraform creates `${ENV}-api-migrate` once, then **ignores** later image
-   changes on the job. While Cloud Build skips migrate, it never updates that
-   image either. Before stamp, point the job at a post-merge webapp image that
-   contains Alembic:
+   The job image may lag the latest webapp build. Before stamp, point the job
+   at a post-merge webapp image that contains Alembic:
 
    ```bash
    # Use the COMMIT_SHA (or :latest) from the merge deploy that includes alembic/
@@ -114,10 +117,13 @@ Or run the automated check: `uv run pytest tests/alembic -q`
 6. Enable auto-migrate on the **live** webapp trigger (Console):
    - Trigger: `edvise-api-web-dev` (project `dev-sst-02`)
    - Substitution: `_SKIP_API_MIGRATE` = `false`
-   - Leave other env triggers at `true` until those DBs are stamped and have
-     `${_ENVIRONMENT}-api-migrate`.
-   - Do **not** rely on a full `dev-terraform` apply to flip this; that apply can
-     reconcile large unrelated drift. Prefer Console (or a narrowly scoped change).
+   - Confirm that trigger’s `_ENVIRONMENT` is the env you stamped (e.g. `dev`).
+   - **Do not** set `_SKIP_API_MIGRATE=false` on `edvise-api-web-qa` (or other
+     shared-YAML triggers) while their `_ENVIRONMENT` still points at `dev` —
+     that would run `dev-api-migrate` from a QA deploy.
+   - Leave other env triggers without `false` until those DBs are stamped and
+     have `${_ENVIRONMENT}-api-migrate`.
+   - Do **not** rely on a full `dev-terraform` apply to flip this.
 7. Re-run webapp Cloud Build (or push a no-op commit); confirm the
    `RUN api-migrate job` step updates/executes `${_ENVIRONMENT}-api-migrate` with
    `--wait` before deploy.


### PR DESCRIPTION
## Description

Wires the **live** webapp deploy path (`cloudbuild-webapp.yaml` / `edvise-api-web-dev`) to run `${_ENVIRONMENT}-api-migrate` (`gcloud run jobs update` + `execute --wait`) before Cloud Run deploy.

- Default `_SKIP_API_MIGRATE` is `"true"`; migrate runs only when the trigger sets `_SKIP_API_MIGRATE=false` (fail-closed toward skip).

After merge: set `_SKIP_API_MIGRATE=false` on **`edvise-api-web-dev` only** (dev is already stamped; `dev-api-migrate` exists). Leave QA/other triggers alone.

## Asana Task
https://app.asana.com/1/6325821815997/project/1208486153653829/task/1217099208609550?focus=true

## Deployment Readiness*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
  - N/A for Cloud Build YAML; YAML parse-checked locally; cutover docs updated
- [ ] Typical manual testing in the local env browser, dev pipeline, etc.
  - After merge + Console flip: confirm `RUN api-migrate job` then deploy on next `edvise-api-web-dev` build; smoke UI/API

### Deployment Notes

Describe or check:

- [ ]  No special deployment steps required

**Post-merge (required for auto-migrate on dev):**

1. Cloud Build → Triggers → `edvise-api-web-dev` → set `_SKIP_API_MIGRATE=false` (confirm `_ENVIRONMENT=dev`).
2. Do **not** set false on `edvise-api-web-qa` while `_ENVIRONMENT` is still `dev`.
3. Re-run webapp build or push a no-op; confirm migrate step succeeds before deploy.

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)
  - Or set `_SKIP_API_MIGRATE` back to `true` / unset on the trigger to skip migrate immediately without revert

## Reviewer Guidance / Questions*

- Dev DB is stamped at `20260803_596894`; `dev-api-migrate` was created via `gcloud`

## Screenshots / Testing Evidence*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

*Optional

Made with [Cursor](https://cursor.com)